### PR TITLE
No Controller

### DIFF
--- a/SendgridParquetLogger/Controllers/HealthController.cs
+++ b/SendgridParquetLogger/Controllers/HealthController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿#if UseSwagger
+using Microsoft.AspNetCore.Mvc;
 
 namespace SendgridParquetLogger.Controllers;
 
@@ -13,3 +14,4 @@ public class HealthController(TimeProvider timeProvider) : ControllerBase
         return Ok(new { status = "healthy", timestamp = timeProvider.GetUtcNow() });
     }
 }
+#endif

--- a/SendgridParquetLogger/Controllers/WebhookController.cs
+++ b/SendgridParquetLogger/Controllers/WebhookController.cs
@@ -10,7 +10,6 @@ namespace SendgridParquetLogger.Controllers;
 [ApiController]
 [Route("webhook")]
 public class WebhookController(
-    ILogger<WebhookController> logger,
     WebhookHelper webhookHelper
 ) : ControllerBase
 {

--- a/SendgridParquetLogger/Controllers/WebhookController.cs
+++ b/SendgridParquetLogger/Controllers/WebhookController.cs
@@ -3,11 +3,7 @@ using System.Net;
 
 using Microsoft.AspNetCore.Mvc;
 
-using SendgridParquet.Shared;
-
 using SendgridParquetLogger.Helper;
-
-using ZLogger;
 
 namespace SendgridParquetLogger.Controllers;
 
@@ -21,11 +17,10 @@ public class WebhookController(
     [HttpPost("sendgrid")]
     public async Task<IActionResult> ReceiveSendGridEvents(CancellationToken ct)
     {
-        var (status, body) = await webhookHelper.ProcessReceiveSendGridEventsAsync(Request.BodyReader, Request.Headers, ct);
+        var (status, body) = await webhookHelper.ProcessReceiveSendGridEventsAsync(Request.Body, Request.Headers, ct);
         return status == HttpStatusCode.OK
             ? Ok(body)
             : StatusCode((int)status, body);
     }
-
 }
 #endif

--- a/SendgridParquetLogger/Controllers/WebhookController.cs
+++ b/SendgridParquetLogger/Controllers/WebhookController.cs
@@ -18,18 +18,13 @@ namespace SendgridParquetLogger.Controllers;
 [Route("webhook")]
 public class WebhookController(
     ILogger<WebhookController> logger,
-    TimeProvider timeProvider,
-    ParquetService parquetService,
-    RequestValidator requestValidator,
-    S3StorageService s3StorageService
+    WebhookHelper webhookHelper
 ) : ControllerBase
 {
-    private const int MaxBodyBytes = 1 * 1024 * 1024; // 1MB
-
     [HttpPost("sendgrid")]
     public async Task<IActionResult> ReceiveSendGridEvents(CancellationToken ct)
     {
-        var (httpStatusCode, events) = await ReadSendGridEvents(Request.BodyReader, Request.Headers, ct);
+        var (httpStatusCode, events) = await webhookHelper.ReadSendGridEvents(Request.BodyReader, Request.Headers, ct);
         if (httpStatusCode != HttpStatusCode.OK)
         {
             logger.ZLogWarning($"Failed to read request body: {httpStatusCode}");
@@ -46,7 +41,7 @@ public class WebhookController(
 
             logger.ZLogInformation($"Received {events.Count} events from SendGrid");
 
-            ICollection<HttpStatusCode> results = await WriteParquetGroupByYmd(events, ct);
+            ICollection<HttpStatusCode> results = await webhookHelper.WriteParquetGroupByYmd(events, ct);
 
             var nonOkResults = results.Where(x => x != HttpStatusCode.OK).ToArray();
             return nonOkResults.Any()
@@ -66,77 +61,4 @@ public class WebhookController(
         }
     }
 
-    private async Task<(HttpStatusCode, ICollection<SendGridEvent>)> ReadSendGridEvents(PipeReader reader,
-        IHeaderDictionary requestHeaders, CancellationToken ct)
-    {
-        ReadResult result = await reader.ReadAtLeastAsync(MaxBodyBytes, ct);
-        ReadOnlySequence<byte> buffer = result.Buffer;
-        if (result.IsCanceled || result.IsCompleted && buffer.Length == 0)
-        {
-            return (HttpStatusCode.BadRequest, Array.Empty<SendGridEvent>());
-        }
-        // PipeReader の一般的使い方としては ループさせて AdvanceTo を呼び出すのが想定されているが、ここでは一度で必要分をすべて読み取る
-
-        string payload = Encoding.UTF8.GetString(buffer);
-
-        switch (requestValidator.VerifySignature(payload, requestHeaders))
-        {
-            case RequestValidator.RequestValidatorResult.Verified:
-#if DEBUG
-            // DEBUG ビルド時は NotConfigured も許可
-            case RequestValidator.RequestValidatorResult.NotConfigured:
-#endif
-                try
-                {
-                    var events = JsonSerializer.Deserialize<SendGridEvent[]>(payload) ?? [];
-                    return (HttpStatusCode.OK, events);
-                }
-                catch (JsonException)
-                {
-                    // return BadRequest
-                }
-                break;
-        }
-        return (HttpStatusCode.BadRequest, Array.Empty<SendGridEvent>());
-    }
-
-    private async Task<List<HttpStatusCode>> WriteParquetGroupByYmd(IEnumerable<SendGridEvent> events, CancellationToken ct)
-    {
-        DateTimeOffset now = timeProvider.GetUtcNow();
-        var results = new List<HttpStatusCode>(2); // 日をまたいだ場合に2つに分割される それ以上あった場合でも自動的に拡張されるので問題ない
-        foreach (var grp in events
-                     .Select(sendgridEvent => (sendgridEvent, timestamp: JstExtension.JstUnixTimeSeconds(sendgridEvent.Timestamp)))
-                     .GroupBy(pair => new DateOnly(pair.timestamp.Year, pair.timestamp.Month, pair.timestamp.Day) /* 日単位で分割 */, pair => pair.sendgridEvent))
-        {
-            DateOnly targetDay = grp.Key;
-            HttpStatusCode result = await WriteParquet(grp, targetDay, now, ct);
-            results.Add(result);
-        }
-        return results;
-    }
-
-    private async ValueTask<HttpStatusCode> WriteParquet(IEnumerable<SendGridEvent> eventsEnumerable,
-        DateOnly targetDay,
-        DateTimeOffset now,
-        CancellationToken ct)
-    {
-        var events = eventsEnumerable.ToArray();
-        await using var parquetData = await parquetService.ConvertToParquetAsync(events);
-        if (parquetData == null)
-        {
-            logger.ZLogError($"Failed to convert events to Parquet format");
-            return HttpStatusCode.InternalServerError;
-        }
-
-        string fileName = SendGridPathUtility.GetParquetNonCompactionFileName(targetDay, parquetData);
-        bool uploadSuccess = await s3StorageService.PutObjectAsync(parquetData, fileName, now, ct);
-        if (!uploadSuccess)
-        {
-            logger.ZLogError($"Failed to upload Parquet file to S3");
-            return HttpStatusCode.InternalServerError;
-        }
-
-        logger.ZLogInformation($"Successfully processed and stored {targetDay:yyyy/MM/dd} events in {fileName}");
-        return HttpStatusCode.OK;
-    }
 }

--- a/SendgridParquetLogger/Controllers/WebhookController.cs
+++ b/SendgridParquetLogger/Controllers/WebhookController.cs
@@ -1,8 +1,5 @@
-﻿using System.Buffers;
-using System.IO.Pipelines;
+﻿#if UseSwagger
 using System.Net;
-using System.Text;
-using System.Text.Json;
 
 using Microsoft.AspNetCore.Mvc;
 
@@ -24,41 +21,11 @@ public class WebhookController(
     [HttpPost("sendgrid")]
     public async Task<IActionResult> ReceiveSendGridEvents(CancellationToken ct)
     {
-        var (httpStatusCode, events) = await webhookHelper.ReadSendGridEvents(Request.BodyReader, Request.Headers, ct);
-        if (httpStatusCode != HttpStatusCode.OK)
-        {
-            logger.ZLogWarning($"Failed to read request body: {httpStatusCode}");
-            return StatusCode((int)httpStatusCode, "Failed to read request body");
-        }
-
-        try
-        {
-            if (!events.Any())
-            {
-                logger.ZLogWarning($"Received empty or null events");
-                return BadRequest("No events received");
-            }
-
-            logger.ZLogInformation($"Received {events.Count} events from SendGrid");
-
-            ICollection<HttpStatusCode> results = await webhookHelper.WriteParquetGroupByYmd(events, ct);
-
-            var nonOkResults = results.Where(x => x != HttpStatusCode.OK).ToArray();
-            return nonOkResults.Any()
-                ? new StatusCodeResult((int)nonOkResults.First())
-                : Ok(new
-                {
-#if DEBUG
-                    message = "Events processed successfully",
-#endif
-                    count = events.Count
-                });
-        }
-        catch (Exception ex)
-        {
-            logger.ZLogError(ex, $"Error processing SendGrid webhook");
-            return StatusCode(500, "Internal server error");
-        }
+        var (status, body) = await webhookHelper.ProcessReceiveSendGridEventsAsync(Request.BodyReader, Request.Headers, ct);
+        return status == HttpStatusCode.OK
+            ? Ok(body)
+            : StatusCode((int)status, body);
     }
 
 }
+#endif

--- a/SendgridParquetLogger/Helper/RequestValidator.cs
+++ b/SendgridParquetLogger/Helper/RequestValidator.cs
@@ -54,7 +54,8 @@ public class RequestValidator
         PublicKey? publicKey = _lazyPublicKey.Value;
         if (publicKey == null)
         {
-            return _options.VERIFICATIONKEY switch {
+            return _options.VERIFICATIONKEY switch
+            {
                 "VERIFIED" => RequestValidatorResult.Verified,
                 "FAILED" => RequestValidatorResult.Failed,
                 _ => RequestValidatorResult.NotConfigured,

--- a/SendgridParquetLogger/Helper/WebhookHelper.cs
+++ b/SendgridParquetLogger/Helper/WebhookHelper.cs
@@ -28,7 +28,17 @@ public class WebhookHelper(
         IHeaderDictionary requestHeaders,
         CancellationToken ct)
     {
-        using var ms = new MemoryStream();
+        int initialCapacity = 0;
+        if (requestHeaders.ContentLength is long contentLength && contentLength > 0)
+        {
+            long capped = Math.Min(contentLength, MaxBodyBytes);
+            if (capped <= int.MaxValue)
+            {
+                initialCapacity = (int)capped;
+            }
+        }
+
+        using var ms = initialCapacity > 0 ? new MemoryStream(initialCapacity) : new MemoryStream();
         long total = 0;
         while (true)
         {

--- a/SendgridParquetLogger/Helper/WebhookHelper.cs
+++ b/SendgridParquetLogger/Helper/WebhookHelper.cs
@@ -1,0 +1,103 @@
+using System.Buffers;
+using System.IO.Pipelines;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+
+using Microsoft.AspNetCore.Http;
+
+using SendgridParquet.Shared;
+
+using ZLogger;
+
+namespace SendgridParquetLogger.Helper;
+
+public class WebhookHelper(
+    ILogger<WebhookHelper> logger,
+    TimeProvider timeProvider,
+    ParquetService parquetService,
+    RequestValidator requestValidator,
+    S3StorageService s3StorageService
+)
+{
+    private const int MaxBodyBytes = 1 * 1024 * 1024; // 1MB
+
+    public async Task<(HttpStatusCode, ICollection<SendGridEvent>)> ReadSendGridEvents(
+        PipeReader reader,
+        IHeaderDictionary requestHeaders,
+        CancellationToken ct)
+    {
+        ReadResult result = await reader.ReadAtLeastAsync(MaxBodyBytes, ct);
+        ReadOnlySequence<byte> buffer = result.Buffer;
+        if (result.IsCanceled || result.IsCompleted && buffer.Length == 0)
+        {
+            return (HttpStatusCode.BadRequest, Array.Empty<SendGridEvent>());
+        }
+
+        string payload = Encoding.UTF8.GetString(buffer);
+
+        switch (requestValidator.VerifySignature(payload, requestHeaders))
+        {
+            case RequestValidator.RequestValidatorResult.Verified:
+#if DEBUG
+            // DEBUG ビルド時は NotConfigured も許可
+            case RequestValidator.RequestValidatorResult.NotConfigured:
+#endif
+                try
+                {
+                    var events = JsonSerializer.Deserialize<SendGridEvent[]>(payload) ?? [];
+                    return (HttpStatusCode.OK, events);
+                }
+                catch (JsonException)
+                {
+                    // return BadRequest
+                }
+                break;
+        }
+        return (HttpStatusCode.BadRequest, Array.Empty<SendGridEvent>());
+    }
+
+    public async Task<List<HttpStatusCode>> WriteParquetGroupByYmd(
+        IEnumerable<SendGridEvent> events,
+        CancellationToken ct)
+    {
+        DateTimeOffset now = timeProvider.GetUtcNow();
+        var results = new List<HttpStatusCode>(2);
+        foreach (var grp in events
+                     .Select(sendgridEvent => (sendgridEvent, timestamp: JstExtension.JstUnixTimeSeconds(sendgridEvent.Timestamp)))
+                     .GroupBy(pair => new DateOnly(pair.timestamp.Year, pair.timestamp.Month, pair.timestamp.Day), pair => pair.sendgridEvent))
+        {
+            DateOnly targetDay = grp.Key;
+            HttpStatusCode result = await WriteParquet(grp, targetDay, now, ct);
+            results.Add(result);
+        }
+        return results;
+    }
+
+    public async ValueTask<HttpStatusCode> WriteParquet(
+        IEnumerable<SendGridEvent> eventsEnumerable,
+        DateOnly targetDay,
+        DateTimeOffset now,
+        CancellationToken ct)
+    {
+        var events = eventsEnumerable.ToArray();
+        await using var parquetData = await parquetService.ConvertToParquetAsync(events);
+        if (parquetData == null)
+        {
+            logger.ZLogError($"Failed to convert events to Parquet format");
+            return HttpStatusCode.InternalServerError;
+        }
+
+        string fileName = SendGridPathUtility.GetParquetNonCompactionFileName(targetDay, parquetData);
+        bool uploadSuccess = await s3StorageService.PutObjectAsync(parquetData, fileName, now, ct);
+        if (!uploadSuccess)
+        {
+            logger.ZLogError($"Failed to upload Parquet file to S3");
+            return HttpStatusCode.InternalServerError;
+        }
+
+        logger.ZLogInformation($"Successfully processed and stored {targetDay:yyyy/MM/dd} events in {fileName}");
+        return HttpStatusCode.OK;
+    }
+}
+

--- a/SendgridParquetLogger/Helper/WebhookHelper.cs
+++ b/SendgridParquetLogger/Helper/WebhookHelper.cs
@@ -35,7 +35,8 @@ public class WebhookHelper(
             return (HttpStatusCode.BadRequest, Array.Empty<SendGridEvent>());
         }
 
-        switch (requestValidator.VerifySignature(payload, requestHeaders))
+        var requestValidatorResult = requestValidator.VerifySignature(payload, requestHeaders);
+        switch (requestValidatorResult)
         {
             case RequestValidator.RequestValidatorResult.Verified:
 #if DEBUG
@@ -51,6 +52,9 @@ public class WebhookHelper(
                 {
                     // return BadRequest
                 }
+                break;
+            default:
+                logger.ZLogInformation($"VerigySignature: {requestValidatorResult}");
                 break;
         }
         return (HttpStatusCode.BadRequest, Array.Empty<SendGridEvent>());

--- a/SendgridParquetLogger/Helper/WebhookHelper.cs
+++ b/SendgridParquetLogger/Helper/WebhookHelper.cs
@@ -1,4 +1,4 @@
-using System.Buffers;
+﻿using System.Buffers;
 using System.IO;
 using System.IO.Pipelines;
 using System.Net;

--- a/SendgridParquetLogger/Program.cs
+++ b/SendgridParquetLogger/Program.cs
@@ -67,9 +67,6 @@ var app = builder.Build();
 }
 #endif
 
-app.UseHttpsRedirection();
-// app.UseAuthorization(); // このアプリでは認証しないためコメントアウト
-
 #if UseSwagger
 app.MapControllers();
 #else
@@ -81,7 +78,7 @@ app.MapGet("/health6QQl", (TimeProvider timeProvider) =>
 
 app.MapPost("/webhook/sendgrid", async (HttpContext httpContext, WebhookHelper webhookHelper, CancellationToken ct) =>
 {
-    var (status, body) = await webhookHelper.ProcessReceiveSendGridEventsAsync(httpContext.Request.BodyReader, httpContext.Request.Headers, ct);
+    var (status, body) = await webhookHelper.ProcessReceiveSendGridEventsAsync(httpContext.Request.Body, httpContext.Request.Headers, ct);
     if (status == System.Net.HttpStatusCode.OK)
     {
         return Results.Ok(body);

--- a/SendgridParquetLogger/Program.cs
+++ b/SendgridParquetLogger/Program.cs
@@ -45,6 +45,7 @@ builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddSingleton<ParquetService>(); // 無状態のため AddSingleton
 builder.Services.AddSingleton<RequestValidator>(); // 処理は無状態 PublicKey の生成をキャッシュするため AddSingleton
 builder.Services.AddHttpClient<S3StorageService>();
+builder.Services.AddScoped<WebhookHelper>();
 
 var app = builder.Build();
 

--- a/SendgridParquetLogger/appsettings.Development.json
+++ b/SendgridParquetLogger/appsettings.Development.json
@@ -5,6 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "SENDGRID": {
+    "VERIFICATIONKEY": ""
+  },
   "S3": {
     "ACCESSKEY": "minioadmin",
     "SECRETKEY": "minioadmin",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - S3__SERVICEURL=${S3__SERVICEURL:-http://minio:9000}
       - S3__REGION=${S3__REGION:-jp-north-1}
       - S3__BUCKETNAME=${S3__BUCKETNAME:-sendgrid-events}
-      - SENDGRID__VERIFICATIONKEY=${SENDGRID__VERIFICATIONKEY:-}
+      - SENDGRID__VERIFICATIONKEY=${SENDGRID__VERIFICATIONKEY:-VERIFIED}
       - ASPNETCORE_URLS=http://+:5206
     depends_on:
       - minio


### PR DESCRIPTION
    ## プルリクエスト案
    - タイトル: Refactor: WebhookHelper への集約 + UseSwagger 条件分岐 + PipeReader/Content-Length 改善
    - ブランチ: featuers/nocontroller → main

    ### 目的 / 背景
    - Controller と Minimal API の二重実装を避け、処理本体を 1 箇所に集約して保守性・テスト容易性を向上。
    - ビルドシンボル `UseSwagger` の有無で、Controller ベースと Minimal API を切り替え可能に。
    - Kestrel によるリクエストボディ自動ドレイン警告を解消し、Content-Length を活用したメモリ効率改善を実施。

    ### 主要変更
    - 追加: `SendgridParquetLogger/Helper/WebhookHelper.cs`
      - `ReadSendGridEvents(...)`: PipeReader の正しい読み取り（ReadAsync ループ + AdvanceTo）。1MB 超過ガード、空ボディ
は 400。
      - `WriteParquetGroupByYmd(...)`: JST 日単位でグルーピングし Parquet 生成・S3 へ保存。
      - `WriteParquet(...)`: Parquet 生成と S3 アップロード。
      - `ProcessReceiveSendGridEventsAsync(...)`: 受信→検証→保存までの本体処理を共通化（戻り値 `(Status, Body)`）。
    - 変更: `SendgridParquetLogger/Controllers/WebhookController.cs`
      - ファイル全体を `#if UseSwagger` でガード。
      - `ReceiveSendGridEvents()` は Helper の共通処理を呼び出すだけに簡素化。
    - 変更: `SendgridParquetLogger/Controllers/HealthController.cs`
      - ファイル全体を `#if UseSwagger` でガード。
    - 変更: `SendgridParquetLogger/Program.cs`
      - `#if UseSwagger` の場合のみ `builder.Services.AddControllers()` と `app.MapControllers()` を使用。
      - それ以外は Minimal API で `GET /health6QQl` と `POST /webhook/sendgrid` を定義（Helper で共通処理呼び出し）。
      - `builder.Services.AddScoped<WebhookHelper>();` を追加し DI 登録。
    - 改善: `Content-Length` がある場合は `MemoryStream` 初期容量を事前確保（上限 1MB）。

    ### 互換性・動作
    - API パスは従来どおり `/webhook/sendgrid`, `/health6QQl` を維持。
    - DEBUG 時は SendGrid 署名 NotConfigured も許容。
    - 1MB 超過リクエストは 400 BadRequest を返却。

    ### テスト / 確認
    - `dotnet build` 成功（0 Error）。
    - `UseSwagger` 有効/無効のいずれでもビルド/ルーティングが成立。
    - 自動ドレイン警告が出ないことを確認（PipeReader の AdvanceTo 修正）。

    ### リスクとロールバック
    - 影響範囲は Webhook 受信とヘルスチェックのみ。問題発生時は当該コミットのリバートでロールバック可能。

    ### 変更ファイル一覧
    - 追加: `SendgridParquetLogger/Helper/WebhookHelper.cs`
    - 変更: `SendgridParquetLogger/Controllers/WebhookController.cs`
    - 変更: `SendgridParquetLogger/Controllers/HealthController.cs`
    - 変更: `SendgridParquetLogger/Program.cs`

    ## コードレビュー所見 / 改善提案
    - 責務分離: WebhookHelper に集約したことで重複排除・テスト容易性が向上。妥当です。
    - メモリ効率: `Content-Length` に基づく初期容量確保は合理的（上限 1MB キャップ）。
    - API 応答統一: Minimal API 側のエラー応答で本文を返すかの挙動を Controller と揃えると一貫性向上。
    - 例外/キャンセル: `OperationCanceledException` などキャンセル時の戻り値方針（499相当 or 400/500 など）を明文化し、
共通メソッドでマッピングするとより堅牢。
    - 将来の最適化: 署名検証要件が満たせるなら `JsonSerializer.DeserializeAsync(Stream)` の活用で追加アロケーションをさ
らに削減可能。
    - テスト提案: 署名 OK/NG、JSON 不正、空ボディ、1MB 超過、日跨ぎグルーピング、S3 失敗の各ケースを単体テスト化すると回帰耐性が高まります。