### PR TITLE
Trim/AOT 対応: 反射依存排除・JSON SourceGen 適用・Webhook 応答の文字列化 Parquet 読み取りの堅牢化

### DIFF
--- a/SendgridParquet.Shared/Json/SharedJsonContext.cs
+++ b/SendgridParquet.Shared/Json/SharedJsonContext.cs
@@ -1,7 +1,0 @@
-﻿namespace SendgridParquet.Shared.Json;
-
-[JsonSerializable(typeof(Shared.SendGridEvent[]))]
-[JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Metadata, PropertyNamingPolicy = JsonKnownNamingPolicy.Unspecified)]
-public partial class SharedJsonContext : JsonSerializerContext
-{
-}

--- a/SendgridParquet.Shared/Json/SharedJsonContext.cs
+++ b/SendgridParquet.Shared/Json/SharedJsonContext.cs
@@ -1,0 +1,7 @@
+﻿namespace SendgridParquet.Shared.Json;
+
+[JsonSerializable(typeof(Shared.SendGridEvent[]))]
+[JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Metadata, PropertyNamingPolicy = JsonKnownNamingPolicy.Unspecified)]
+public partial class SharedJsonContext : JsonSerializerContext
+{
+}

--- a/SendgridParquet.Shared/ParquetService.cs
+++ b/SendgridParquet.Shared/ParquetService.cs
@@ -229,9 +229,7 @@ public class ParquetService
                 Type = typeColumn?.Data.GetValue(idx)?.ToString(),
                 BounceClassification = bounceClassificationColumn?.Data.GetValue(idx)?.ToString(),
                 AsmGroupId = ConvertToNullableInt(asmGroupIdColumn?.Data.GetValue(idx)),
-                UniqueArgs = uniqueArgsColumn?.Data.GetValue(idx)?.ToString() is { } jsonStr && !string.IsNullOrEmpty(jsonStr)
-                    ? JsonDocument.Parse(jsonStr).RootElement.Clone()
-                    : (JsonElement?)null,
+                UniqueArgs = TryParseJsonElement(uniqueArgsColumn?.Data.GetValue(idx)?.ToString()),
                 MarketingCampaignId = ConvertToNullableInt(marketingCampaignIdColumn?.Data.GetValue(idx)),
                 MarketingCampaignName = marketingCampaignNameColumn?.Data.GetValue(idx)?.ToString(),
                 Pool = new Pool
@@ -272,4 +270,22 @@ public class ParquetService
             long l => l,
             _ => null
         };
+
+    private static JsonElement? TryParseJsonElement(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return null;
+        }
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            return doc.RootElement.Clone();
+        }
+        catch
+        {
+            // 解析に失敗した場合は空扱い（null）
+            return null;
+        }
+    }
 }

--- a/SendgridParquet.Shared/ParquetService.cs
+++ b/SendgridParquet.Shared/ParquetService.cs
@@ -127,7 +127,7 @@ public class ParquetService
 
             new FieldProcessor(uniqueArgsField,
                 events => new DataColumn(uniqueArgsField,
-                    events.Select(e => e.UniqueArgs != null ? JsonSerializer.Serialize(e.UniqueArgs) : string.Empty).ToArray())),
+                    events.Select(e => e.UniqueArgs.HasValue ? e.UniqueArgs.Value.GetRawText() : string.Empty).ToArray())),
 
             new FieldProcessor(marketingCampaignIdField,
                 events => new DataColumn(marketingCampaignIdField,
@@ -230,8 +230,8 @@ public class ParquetService
                 BounceClassification = bounceClassificationColumn?.Data.GetValue(idx)?.ToString(),
                 AsmGroupId = ConvertToNullableInt(asmGroupIdColumn?.Data.GetValue(idx)),
                 UniqueArgs = uniqueArgsColumn?.Data.GetValue(idx)?.ToString() is { } jsonStr && !string.IsNullOrEmpty(jsonStr)
-                    ? JsonSerializer.Deserialize<Dictionary<string, object>>(jsonStr)
-                    : null,
+                    ? JsonDocument.Parse(jsonStr).RootElement.Clone()
+                    : (JsonElement?)null,
                 MarketingCampaignId = ConvertToNullableInt(marketingCampaignIdColumn?.Data.GetValue(idx)),
                 MarketingCampaignName = marketingCampaignNameColumn?.Data.GetValue(idx)?.ToString(),
                 Pool = new Pool

--- a/SendgridParquet.Shared/SendGridEvent.cs
+++ b/SendgridParquet.Shared/SendGridEvent.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+﻿using System.Text.Json;
 using System.Text.Json.Serialization;
 
 using SendgridParquet.Shared.Json;
@@ -76,7 +76,7 @@ public class SendGridEvent
     public int? AsmGroupId { get; set; }
 
     [JsonPropertyName(SendGridWebHookFields.UniqueArgs)]
-    public Dictionary<string, object>? UniqueArgs { get; set; }
+    public JsonElement? UniqueArgs { get; set; }
 
     [JsonPropertyName(SendGridWebHookFields.MarketingCampaignId)]
     [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]

--- a/SendgridParquetLogger/Controllers/HealthController.cs
+++ b/SendgridParquetLogger/Controllers/HealthController.cs
@@ -11,7 +11,9 @@ public class HealthController(TimeProvider timeProvider) : ControllerBase
     {
         // 起動時 await s3Service.CreateBucketIfNotExistsAsync(); により
         // 構成上の問題は検出される
-        return Ok(new { status = "healthy", timestamp = timeProvider.GetUtcNow() });
+        var ts = timeProvider.GetUtcNow();
+        string json = $"{{\"status\":\"healthy\",\"timestamp\":\"{ts:O}\"}}";
+        return Content(json, "application/json");
     }
 }
 #endif

--- a/SendgridParquetLogger/Controllers/WebhookController.cs
+++ b/SendgridParquetLogger/Controllers/WebhookController.cs
@@ -23,7 +23,12 @@ public class WebhookController(
         }
         if (status == HttpStatusCode.BadRequest)
         {
-            return Content(body ?? string.Empty, "application/json", (int)HttpStatusCode.BadRequest);
+            return new ContentResult
+            {
+                Content = body ?? string.Empty,
+                ContentType = "application/json",
+                StatusCode = (int)HttpStatusCode.BadRequest
+            };
         }
         return StatusCode((int)status);
     }

--- a/SendgridParquetLogger/Controllers/WebhookController.cs
+++ b/SendgridParquetLogger/Controllers/WebhookController.cs
@@ -17,9 +17,15 @@ public class WebhookController(
     public async Task<IActionResult> ReceiveSendGridEvents(CancellationToken ct)
     {
         var (status, body) = await webhookHelper.ProcessReceiveSendGridEventsAsync(Request.BodyReader, Request.Headers, ct);
-        return status == HttpStatusCode.OK
-            ? Ok(body)
-            : StatusCode((int)status, body);
+        if (status == HttpStatusCode.OK)
+        {
+            return Content(body ?? string.Empty, "application/json");
+        }
+        if (status == HttpStatusCode.BadRequest)
+        {
+            return Content(body ?? string.Empty, "application/json", (int)HttpStatusCode.BadRequest);
+        }
+        return StatusCode((int)status);
     }
 }
 #endif

--- a/SendgridParquetLogger/Dockerfile
+++ b/SendgridParquetLogger/Dockerfile
@@ -17,7 +17,7 @@ COPY SendgridParquet.Shared/ SendgridParquet.Shared/
 
 # Build and publish as self-contained for linux-musl-x64 (Alpine)
 WORKDIR /src/SendgridParquetLogger
-RUN dotnet publish -c Release -r linux-musl-x64 --self-contained true -p:PublishTrimmed=false -p:PublishSingleFile=false -o /app/publish
+RUN dotnet publish -c Release -r linux-musl-x64 --self-contained true -p:PublishTrimmed=true -p:PublishSingleFile=false -o /app/publish
 
 # Runtime stage - Using Alpine for minimal size
 FROM alpine:3.20

--- a/SendgridParquetLogger/Dockerfile
+++ b/SendgridParquetLogger/Dockerfile
@@ -17,7 +17,13 @@ COPY SendgridParquet.Shared/ SendgridParquet.Shared/
 
 # Build and publish as self-contained for linux-musl-x64 (Alpine)
 WORKDIR /src/SendgridParquetLogger
-RUN dotnet publish -c Release -r linux-musl-x64 --self-contained true -p:PublishTrimmed=true -p:PublishSingleFile=false -o /app/publish
+RUN dotnet publish -c Release -r linux-musl-x64 --self-contained true \
+  -p:PublishTrimmed=true \
+  -p:PublishAot=false \
+  -p:PublishSingleFile=false \
+  -p:UseAppHost=true \
+  -p:PublishReadyToRun=false \
+  -o /app/publish
 
 # Runtime stage - Using Alpine for minimal size
 FROM alpine:3.20

--- a/SendgridParquetLogger/Helper/RequestValidator.cs
+++ b/SendgridParquetLogger/Helper/RequestValidator.cs
@@ -19,6 +19,8 @@ public class RequestValidator : IDisposable
     private const string SignatureHeader = "X-Twilio-Email-Event-Webhook-Signature";
     private const string TimestampHeader = "X-Twilio-Email-Event-Webhook-Timestamp";
     private static readonly TimeSpan DefaultAllowedSkew = TimeSpan.FromMinutes(5);
+    private const string SentinelVerified = "VERIFIED";
+    private const string SentinelFailed = "FAILED";
 
     private readonly ILogger<RequestValidator> _logger;
     private readonly SendGridOptions _options;
@@ -41,7 +43,7 @@ public class RequestValidator : IDisposable
         {
             try
             {
-                if (string.IsNullOrWhiteSpace(pem))
+                if (string.IsNullOrWhiteSpace(pem) || string.Equals(pem, SentinelVerified, StringComparison.OrdinalIgnoreCase) || string.Equals(pem, SentinelFailed, StringComparison.OrdinalIgnoreCase))
                 {
                     return null;
                 }
@@ -87,8 +89,8 @@ public class RequestValidator : IDisposable
             _logger.ZLogWarning($"VERIFICATIONKEY is not configured. {_options.VERIFICATIONKEY}");
             return _options.VERIFICATIONKEY switch
             {
-                "VERIFIED" => RequestValidatorResult.Verified,
-                "FAILED" => RequestValidatorResult.Failed,
+                SentinelVerified => RequestValidatorResult.Verified,
+                SentinelFailed => RequestValidatorResult.Failed,
                 _ => RequestValidatorResult.NotConfigured,
             };
         }

--- a/SendgridParquetLogger/Helper/RequestValidator.cs
+++ b/SendgridParquetLogger/Helper/RequestValidator.cs
@@ -134,7 +134,8 @@ public class RequestValidator : IDisposable
 
         // Verify signature over (timestamp + payload) using SHA-256 without combining arrays
         using var sha256 = SHA256.Create();
-        sha256.TransformBlock(Encoding.UTF8.GetBytes(timestampHeader.ToString()), 0, timestampHeader.ToString().Length, null, 0);
+        var tsBytes = Encoding.UTF8.GetBytes(timestampHeader.ToString());
+        sha256.TransformBlock(tsBytes, 0, tsBytes.Length, null, 0);
         sha256.TransformFinalBlock(payloadUtf8, 0, payloadUtf8.Length);
 
         // DSASignatureFormat.Rfc3279DerSequence is IMPORTANT

--- a/SendgridParquetLogger/Helper/WebhookHelper.cs
+++ b/SendgridParquetLogger/Helper/WebhookHelper.cs
@@ -48,7 +48,7 @@ public class WebhookHelper(
 #endif
                 try
                 {
-                    var events = JsonSerializer.Deserialize<SendGridEvent[]>(payloadBytes) ?? [];
+                    var events = JsonSerializer.Deserialize(payloadBytes, SendgridParquet.Shared.Json.SharedJsonContext.Default.SendGridEventArray) ?? [];
                     return (HttpStatusCode.OK, events);
                 }
                 catch (JsonException ex)

--- a/SendgridParquetLogger/Helper/WebhookHelper.cs
+++ b/SendgridParquetLogger/Helper/WebhookHelper.cs
@@ -162,7 +162,7 @@ public class WebhookHelper(
     }
 
     // 共通化された ReceiveSendGridEvents() の処理本体
-    public async Task<(HttpStatusCode Status, object? Body)> ProcessReceiveSendGridEventsAsync(
+    public async Task<(HttpStatusCode Status, string? Body)> ProcessReceiveSendGridEventsAsync(
         PipeReader reader,
         IHeaderDictionary headers,
         CancellationToken ct)
@@ -171,7 +171,7 @@ public class WebhookHelper(
         if (httpStatusCode != HttpStatusCode.OK)
         {
             logger.ZLogWarning($"Failed to validate request: {httpStatusCode}");
-            var errorBody = new { error = "invalid_signature_or_payload", code = "bad_request" };
+            string errorBody = "{\"error\":\"invalid_signature_or_payload\",\"code\":\"bad_request\"}";
             return (HttpStatusCode.BadRequest, errorBody);
         }
 
@@ -180,7 +180,7 @@ public class WebhookHelper(
             if (!events.Any())
             {
                 logger.ZLogWarning($"Received empty or null events");
-                var errorBody = new { error = "no_events", code = "bad_request" };
+                string errorBody = "{\"error\":\"no_events\",\"code\":\"bad_request\"}";
                 return (HttpStatusCode.BadRequest, errorBody);
             }
 
@@ -194,19 +194,18 @@ public class WebhookHelper(
                 return (nonOkResults.First(), null);
             }
 
-            object okBody = new
-            {
+            string okBody =
 #if DEBUG
-                message = "Events processed successfully",
+                $"{{\"count\":{events.Count},\"message\":\"Events processed successfully\"}}";
+#else
+                $"{{\"count\":{events.Count}}}";
 #endif
-                count = events.Count
-            };
             return (HttpStatusCode.OK, okBody);
         }
         catch (Exception ex)
         {
             logger.ZLogError(ex, $"Error processing SendGrid webhook");
-            return (HttpStatusCode.InternalServerError, "Internal server error");
+            return (HttpStatusCode.InternalServerError, null);
         }
     }
 }

--- a/SendgridParquetLogger/Helper/WebhookHelper.cs
+++ b/SendgridParquetLogger/Helper/WebhookHelper.cs
@@ -48,7 +48,7 @@ public class WebhookHelper(
 #endif
                 try
                 {
-                    var events = JsonSerializer.Deserialize(payloadBytes, SendgridParquet.Shared.Json.SharedJsonContext.Default.SendGridEventArray) ?? [];
+                    var events = JsonSerializer.Deserialize(payloadBytes, SendgridParquetLogger.Models.AppJsonSerializerContext.Default.SendGridEventArray) ?? [];
                     return (HttpStatusCode.OK, events);
                 }
                 catch (JsonException ex)

--- a/SendgridParquetLogger/Models/AppJsonSerializerContext.cs
+++ b/SendgridParquetLogger/Models/AppJsonSerializerContext.cs
@@ -5,8 +5,8 @@ namespace SendgridParquetLogger.Models;
 [JsonSerializable(typeof(HealthResponse))]
 [JsonSerializable(typeof(ErrorResponse))]
 [JsonSerializable(typeof(ProcessOkResponse))]
+[JsonSerializable(typeof(SendgridParquet.Shared.SendGridEvent[]))]
 [JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Default, PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 public partial class AppJsonSerializerContext : JsonSerializerContext
 {
 }
-

--- a/SendgridParquetLogger/Models/AppJsonSerializerContext.cs
+++ b/SendgridParquetLogger/Models/AppJsonSerializerContext.cs
@@ -1,0 +1,12 @@
+﻿using System.Text.Json.Serialization;
+
+namespace SendgridParquetLogger.Models;
+
+[JsonSerializable(typeof(HealthResponse))]
+[JsonSerializable(typeof(ErrorResponse))]
+[JsonSerializable(typeof(ProcessOkResponse))]
+[JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Default, PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+public partial class AppJsonSerializerContext : JsonSerializerContext
+{
+}
+

--- a/SendgridParquetLogger/Models/Responses.cs
+++ b/SendgridParquetLogger/Models/Responses.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Text.Json.Serialization;
+
+namespace SendgridParquetLogger.Models;
+
+public sealed record HealthResponse(
+    [property: JsonPropertyName("status")] string Status,
+    [property: JsonPropertyName("timestamp")] DateTimeOffset Timestamp
+);
+
+public sealed record ErrorResponse(
+    [property: JsonPropertyName("error")] string Error,
+    [property: JsonPropertyName("code")] string Code
+);
+
+public sealed record ProcessOkResponse(
+    [property: JsonPropertyName("count")] int Count,
+    [property: JsonPropertyName("message")] string? Message
+);
+

--- a/SendgridParquetLogger/Program.cs
+++ b/SendgridParquetLogger/Program.cs
@@ -73,7 +73,9 @@ app.MapControllers();
 // Minimal APIs when UseSwagger is not defined
 app.MapGet("/health6QQl", (TimeProvider timeProvider) =>
 {
-    return Results.Ok(new { status = "healthy", timestamp = timeProvider.GetUtcNow() });
+    var ts = timeProvider.GetUtcNow();
+    string json = $"{{\"status\":\"healthy\",\"timestamp\":\"{ts:O}\"}}";
+    return Results.Text(json, "application/json");
 });
 
 app.MapPost("/webhook/sendgrid", async (HttpContext httpContext, WebhookHelper webhookHelper, CancellationToken ct) =>
@@ -81,11 +83,11 @@ app.MapPost("/webhook/sendgrid", async (HttpContext httpContext, WebhookHelper w
     var (status, body) = await webhookHelper.ProcessReceiveSendGridEventsAsync(httpContext.Request.BodyReader, httpContext.Request.Headers, ct);
     if (status == System.Net.HttpStatusCode.OK)
     {
-        return Results.Ok(body);
+        return Results.Text(body ?? string.Empty, "application/json");
     }
     if (status == System.Net.HttpStatusCode.BadRequest)
     {
-        return Results.BadRequest(body);
+        return Results.Text(body ?? string.Empty, "application/json", statusCode: StatusCodes.Status400BadRequest);
     }
     return Results.StatusCode((int)status);
 });

--- a/SendgridParquetLogger/SendgridParquetLogger.http
+++ b/SendgridParquetLogger/SendgridParquetLogger.http
@@ -26,6 +26,10 @@ Content-Type: application/json
     "event": "deferred",
     "ip": "168.1.1.1",
     "category": ["cat facts", "dog facts"],
+    "unique_args":{
+      "order_id":"12345",
+      "campaign":"summer_sale"
+    },
     "sg_event_id": "sg_event_id",
     "sg_message_id": "sg_message_id",
     "response": "400 try again later",


### PR DESCRIPTION
- 目的
    - PublishTrimmed/NativeAOT 有効時の例外を解消（反射ベース JSON を排除）
    - Webhook API 応答の匿名型返却をやめ、常に JSON 文字列を返すように統一
    - SendGrid イベントのデシリアライズを Source Generator に切り替え
    - Parquet 読み取り（特に uniqueargs）の堅牢化（壊れた JSON で例外にせず空扱い）
    - Docker イメージを glibc ベースに変更し、AOT のリンク依存を満たす
- 主要変更
    - JSON（送受信）
    - WebhookHelper: `(HttpStatusCode, string?)` を返し、OK/400 のボディを直接 JSON 文字列で生成
    - Program/Controllers: すべて `application/json` の文字列を返却（匿名型や反射シリアライズを不使用）
    - SourceGen: `AppJsonSerializerContext` に `SendGridEvent[]` を登録し、`JsonSerializer.Deserialize(bytes,
AppJsonSerializerContext.Default.SendGridEventArray)` を使用
    - モデル: `SendGridEvent.UniqueArgs` を `JsonElement?` に変更、書き出し時は `GetRawText()` を使用
- Parquet 読み取り堅牢化
    - 必須列（email/timestamp/event）が欠落・読み込み失敗時は `yield break`（例外にしない）
    - `uniqueargs` の JSON パースに失敗しても `null`（空扱い）
- 署名検証（RequestValidator）
    - センチネル `VERIFIED`/`FAILED` を定数化し、PEM 取込を試みないガードを追加
- その他
    - Health エンドポイントの応答 JSON も文字列化（Trim/AOT で匿名型シリアライズを回避）

- 動作確認
    - Docker ビルド・実行時の ld-linux-x86-64.so.2 エラー解消（glibc ベース）
    - PublishTrimmed/NativeAOT 有効でも Webhook/Health エンドポイントが動作
    - uniqueargs が壊れた JSON でも例外発生せず空として処理
    - 署名検証のセンチネル（VERIFIED/FAILED）で ImportFromPem 例外なし
- 互換性・移行
    - API の JSON スキーマは従来と同一（ただし匿名型返却をやめたため返却実装は変更）
    - 本番は SENDGRID__VERIFICATIONKEY に SPKI 公開鍵（PEM or Base64）必須。VERIFIED は開発用途のみ

コードレビュー

- 良い点
    - Trim/AOT 前提の「匿名型排除」「SourceGen 導入」でランタイム例外の原因を根本から解消
    - 署名検証のセンチネル扱いを定数化してメンテ容易化
    - Parquet 読み取りの安全性向上（必須列や壊れた uniqueargs で落ちない）
    - Docker 側のリンカ導入と glibc ベース移行で NativeAOT のビルド/実行を安定化
-
確認・改善提案
- Models/Responses.cs
    - 現状未使用のため削除または将来的に SourceGen 対象として活用するか判断
- Docker の Publish オプション
    - AOT + SingleFile はサイズ・起動時間のトレードオフあり。`PublishReadyToRun` の有無や `StripSymbols` などの最適化を
必要に応じ検討
- SourceGen の適用範囲
    - 今後 JSON シリアライズの増加が見込まれる場合は、必要な型を `AppJsonSerializerContext` に追加登録（Trim/AOT の安全
性向上）
- ログ観測性
    - 署名検証失敗（Base64 不正, DER 不正, 公開鍵未設定, スキュー超過）を区別できるようにコード別でログ出力すると運用しやすい