### PR TITLE
昨日分も Compaction 対象に含める（UTC基準）＋命名の明確化

### DIFF
--- a/SendgridParquetViewer/Services/CompactionService.cs
+++ b/SendgridParquetViewer/Services/CompactionService.cs
@@ -116,7 +116,7 @@ public class CompactionService(
     /// <summary>
     /// Compaction対象の日付とパスの一覧を取得する
     /// </summary>
-    /// <param name="olderThanOrEqual">この時刻以前の日付のみを対象とする</param>
+    /// <param name="olderThanOrEqual">この日付以前を対象とする</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     private async Task<IList<(DateOnly dateOnly, string pathPrefix)>> GetCompactionTargetAsync(DateOnly olderThanOrEqual,


### PR DESCRIPTION
- 目的: UTCを基準に「昨日まで」をコンパクション対象とし、時刻取得変数の命名とドキュメントを整備して可読性と意図の一致を
図る。
- 変更内容:
    - now変数をnowUTCへ改名: UTC基準であることを明示。
    - 対象上限日の変数をolderThan→olderThanOrEqualへ改名し、XMLコメントを「この時刻以前」に更新。
    - 対象上限を「UTCの昨日」までに設定（JSTでは9時以降に前日が対象に入る旨をコメントで明示）。
    - RunStatus.StartTime/結果返却のStartTimeにnowUTCを使用。
- 挙動の要点:
    - UTC 00:00を基準に対象日を判定。JSTでは午前9時以降に「前日」が対象に含まれる挙動になる。
- 影響範囲:
    - コンパクション対象日の抽出ロジックとRunStatusの開始時刻のみ。既存API/公開型の破壊的変更なし。
- 動作確認（推奨）:
    - UTCで今日: 2025-09-08 10:00Z の場合、対象上限は 2025-09-07（JST 9時以降で昨日が含まれる）。
    - 疑似S3上のディレクトリ構造（v3raw/YYYY/MM/DD）で、GetCompactionTargetAsyncが上限日を含むことを検証。
    - 既に実行中でMaxRunningDuration以内のケースで再起動抑止を確認。
- 既知の注意点/フォローアップ提案:
    - 判定が「以前」となっている一方、実装の比較演算子が< olderThanOrEqualのままで「昨日」が含まれません。<=
olderThanOrEqualへ修正が必要です（コードレビュー参照）。
    - バッチ処理ループで「残りファイル」をCompactionBatchAsyncへ渡せていないため、同一ファイルを再読込しがちです。
remainFilesを渡すよう修正を提案（コードレビュー参照）。
- リスクとロールバック:
    - 影響は対象日の境界条件とI/Oの挙動に限定。異常が確認された場合は当該コミットをrevertして現行の「昨日を含まない」挙動へ戻せます。
- 関連: 既存issue/PRがあればここに記載

変更ファイル:

- SendgridParquetViewer/Services/CompactionService.cs のみ（10追加/10削除）

命名とコメントの一貫性:
    - nowUTCへの変更は明確で良いです。一方、GetRunStatusAsync等の他メソッドもUTCで統一済みかを軽く確認（本ファイル内はUTCで統一されていました）。
- タイムゾーン仕様の明文化:
    - 「UTC基準で昨日以前＝JSTで9時以降に昨日が対象」はコメント追加済みで良いです。READMEもしくは運用Runbookに仕様として
追記すると、問い合わせ低減に有効。
-
ロックとステータス更新:
    - TryAcquireLockAsyncでS3の条件付きPUTを使っており良い実装。EndTime更新はfinally後に保存しており、例外時にも状態が残
るのは良い。
    - 追加提案: 長時間処理向けに、日付単位の処理完了ごとにRunStatusへ進捗を更新（Best Effort）すると可観測性が上がり
ます。
-
    - CompactionBatchAsyncは最大512MB（MaxBatchSizeBytes）に収まるまでイベントを全件メモリへ積む設計。大規模データでは
ピークメモリが増えるため、可能なら時間帯ごとのストリーミング書き出し（時間グルーピング単位でflush）を将来検討。
    - ListDirectoriesAsync/ListFilesAsyncの実装次第でページングが必要な場合、上流APIでのページング対応確認を推奨。
-
例外処理の粒度:
    - 出力検証失敗時に対象ファイルを削除する設計は安全側で良い。SaveRunStatusAsyncの失敗時はログのみで良いが、リトライ/バックオフがあるとより堅牢。
-
ログの可観測性:
    - 開始/終了、進捗、失敗の各ログは十分。RunStatusのTargetDaysとTargetPathPrefixesはZipで結合しているため、長さ不一致が起きない前提（生成元が同じ）であることをコメントで補足すると後続の保守に親切。
-
テスト観点（推奨追加）:
    - 対象日境界: UTC昨日を上限に、比較演算子<=で昨日が含まれること（UTC/JSTでの境界ケース）。
    - 再入防止: 実行中でMaxRunningDuration以内は開始不可。
    - バッチ処理: remainFilesのみを渡した際、処理済みファイルが再読込されないこと。
    - 出力検証失敗時のロールバック（出力削除）が機能すること。
