### PR TITLE
 Compaction進行状況の可視化

### DIFF
--- a/SendgridParquetViewer/Components/Pages/Compaction.razor
+++ b/SendgridParquetViewer/Components/Pages/Compaction.razor
@@ -35,6 +35,22 @@
                         else
                         {
                             <strong>Status:</strong> <FluentBadge BackgroundColor="var(--accent-fill-rest)">Running</FluentBadge>
+                            <br />
+                            <strong>Completed Days:</strong> @_runStatus.CompletedDays / @_runStatus.TargetDays.Count
+                            @if (_runStatus.CurrentDay.HasValue)
+                            {
+                                <br />
+                                <strong>Current Day:</strong> @_runStatus.CurrentDay.Value
+                                @if (_runStatus.CurrentDayTotalFiles.HasValue && _runStatus.CurrentDayProcessedFiles.HasValue)
+                                {
+                                    <br />
+                                    <strong>Day Progress:</strong> @_runStatus.CurrentDayProcessedFiles / @_runStatus.CurrentDayTotalFiles
+                                }
+                            }
+                            <br />
+                            <strong>Output Files Created:</strong> @_runStatus.OutputFilesCreated
+                            <br />
+                            <small>Last Updated: @_runStatus.LastUpdated.ToString("yyyy-MM-dd HH:mm:ss UTC")</small>
                         }
                         <br />
                         <strong>Target Days:</strong> @_runStatus.TargetDays.Count<br />
@@ -93,10 +109,12 @@
     private bool _isStarting;
     private string _message = string.Empty;
     private MessageIntent _messageIntent = MessageIntent.Info;
+    private System.Threading.Timer? _pollTimer;
 
     protected override async Task OnInitializedAsync()
     {
         await RefreshStatus();
+        EnsurePolling();
     }
 
     private async Task RefreshStatus()
@@ -105,6 +123,7 @@
         try
         {
             _runStatus = await CompactionService.GetRunStatusAsync();
+            EnsurePolling();
         }
         catch (Exception ex)
         {
@@ -149,5 +168,33 @@
         _message = msg;
         _messageIntent = intent;
         StateHasChanged();
+    }
+
+    private void EnsurePolling()
+    {
+        // Start polling when running; stop when completed or no status
+        bool shouldPoll = _runStatus != null && !_runStatus.EndTime.HasValue;
+        if (shouldPoll && _pollTimer == null)
+        {
+            _pollTimer = new System.Threading.Timer(async _ =>
+            {
+                try
+                {
+                    await InvokeAsync(async () => await RefreshStatus());
+                }
+                catch {}
+            }, null, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3));
+        }
+        else if (!shouldPoll && _pollTimer != null)
+        {
+            _pollTimer.Dispose();
+            _pollTimer = null;
+        }
+    }
+
+    public void Dispose()
+    {
+        _pollTimer?.Dispose();
+        _pollTimer = null;
     }
 }

--- a/SendgridParquetViewer/Components/Pages/Compaction.razor
+++ b/SendgridParquetViewer/Components/Pages/Compaction.razor
@@ -94,7 +94,7 @@
 
     @if (!string.IsNullOrEmpty(_message))
     {
-        <FluentMessageBar Intent="@_messageIntent" OnDismiss="() => message = string.Empty">
+        <FluentMessageBar Intent="@_messageIntent" OnDismiss="() => _message = string.Empty">
             @_message
         </FluentMessageBar>
     }

--- a/SendgridParquetViewer/Components/Pages/Compaction.razor
+++ b/SendgridParquetViewer/Components/Pages/Compaction.razor
@@ -26,17 +26,16 @@
                 @if (_runStatus != null)
                 {
                     <p>
-                        <strong>Start Time:</strong> @_runStatus.StartTime.ToString("yyyy-MM-dd HH:mm:ss UTC")<br />
+                        <div><strong>Start Time:</strong> @_runStatus.StartTime.ToString("s")</div>
                         @if (_runStatus.EndTime.HasValue)
                         {
-                            <strong>End Time:</strong> @_runStatus.EndTime.Value.ToString("yyyy-MM-dd HH:mm:ss UTC")<br />
-                            <strong>Status:</strong> <FluentBadge BackgroundColor="var(--success)" Color="white">Completed</FluentBadge>
+                            <div><strong>End Time:</strong> @_runStatus.EndTime.Value.ToString("s")</div>
+                            <div><strong>Status:</strong>Completed</div>
                         }
                         else
                         {
-                            <strong>Status:</strong> <FluentBadge BackgroundColor="var(--accent-fill-rest)">Running</FluentBadge>
-                            <br />
-                            <strong>Completed Days:</strong> @_runStatus.CompletedDays / @_runStatus.TargetDays.Count
+                            <div><strong>Status:</strong>Running</div>
+                            <div><strong>Completed Days:</strong> @(_runStatus.CompletedDays) / @(_runStatus.TargetDays.Count)</div>
                             @if (_runStatus.CurrentDay.HasValue)
                             {
                                 <br />
@@ -48,11 +47,9 @@
                                 }
                             }
                             <br />
-                            <strong>Output Files Created:</strong> @_runStatus.OutputFilesCreated
-                            <br />
-                            <small>Last Updated: @_runStatus.LastUpdated.ToString("yyyy-MM-dd HH:mm:ss UTC")</small>
+                            <div><strong>Output Files Created:</strong> @_runStatus.OutputFilesCreated</div>
+                            <div><small>Last Updated: @_runStatus.LastUpdated.ToString("s")</small></div>
                         }
-                        <br />
                         <strong>Target Days:</strong> @_runStatus.TargetDays.Count<br />
                         <strong>Target Paths:</strong> @string.Join(", ", _runStatus.TargetPathPrefixes.Take(3))
                         @if (_runStatus.TargetPathPrefixes.Count > 3)

--- a/SendgridParquetViewer/Components/Pages/Compaction.razor
+++ b/SendgridParquetViewer/Components/Pages/Compaction.razor
@@ -35,7 +35,7 @@
                         else
                         {
                             <div><strong>Status:</strong>Running</div>
-                            <div><strong>Completed Days:</strong> @(_runStatus.CompletedDays) / @(_runStatus.TargetDays.Count)</div>
+                            <div><strong>Completed Days:</strong> @_runStatus.DaysProgress()</div>
                             @if (_runStatus.CurrentDay.HasValue)
                             {
                                 <br />
@@ -43,7 +43,7 @@
                                 @if (_runStatus.CurrentDayTotalFiles.HasValue && _runStatus.CurrentDayProcessedFiles.HasValue)
                                 {
                                     <br />
-                                    <strong>Day Progress:</strong> @_runStatus.CurrentDayProcessedFiles / @_runStatus.CurrentDayTotalFiles
+                                    <strong>Day Progress:</strong> @_runStatus.CurrentDayProgress()
                                 }
                             }
                             <br />
@@ -106,12 +106,11 @@
     private bool _isStarting;
     private string _message = string.Empty;
     private MessageIntent _messageIntent = MessageIntent.Info;
-    private System.Threading.Timer? _pollTimer;
+    readonly CancellationTokenSource _cts = new CancellationTokenSource();
 
     protected override async Task OnInitializedAsync()
     {
         await RefreshStatus();
-        EnsurePolling();
     }
 
     private async Task RefreshStatus()
@@ -119,8 +118,8 @@
         _isLoadingStatus = true;
         try
         {
-            _runStatus = await CompactionService.GetRunStatusAsync();
-            EnsurePolling();
+            var runStatus = await CompactionService.GetRunStatusAsync();
+            await SetRunStatus(runStatus);
         }
         catch (Exception ex)
         {
@@ -138,7 +137,7 @@
         _isStarting = true;
         try
         {
-            var result = await CompactionService.StartCompactionAsync();
+            var result = await CompactionService.StartCompactionAsync(SetRunStatus, _cts.Token);
             if (result.CanStart)
             {
                 ShowMessage($"Compaction started successfully at {result.StartTime}", MessageIntent.Success);
@@ -167,31 +166,12 @@
         StateHasChanged();
     }
 
-    private void EnsurePolling()
+    private async Task SetRunStatus(RunStatus? runStatus)
     {
-        // Start polling when running; stop when completed or no status
-        bool shouldPoll = _runStatus != null && !_runStatus.EndTime.HasValue;
-        if (shouldPoll && _pollTimer == null)
+        await InvokeAsync(() =>
         {
-            _pollTimer = new System.Threading.Timer(async _ =>
-            {
-                try
-                {
-                    await InvokeAsync(async () => await RefreshStatus());
-                }
-                catch {}
-            }, null, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3));
-        }
-        else if (!shouldPoll && _pollTimer != null)
-        {
-            _pollTimer.Dispose();
-            _pollTimer = null;
-        }
-    }
-
-    public void Dispose()
-    {
-        _pollTimer?.Dispose();
-        _pollTimer = null;
+            _runStatus = runStatus;
+            StateHasChanged();
+        });
     }
 }

--- a/SendgridParquetViewer/Models/RunStatus.cs
+++ b/SendgridParquetViewer/Models/RunStatus.cs
@@ -32,6 +32,8 @@ public class RunStatus
     [JsonPropertyName("currentDayProcessedFiles")]
     public int? CurrentDayProcessedFiles { get; set; }
 
+    public string CurrentDay
+
     [JsonPropertyName("outputFilesCreated")]
     public int OutputFilesCreated { get; set; }
 

--- a/SendgridParquetViewer/Models/RunStatus.cs
+++ b/SendgridParquetViewer/Models/RunStatus.cs
@@ -23,6 +23,8 @@ public class RunStatus
     [JsonPropertyName("completedDays")]
     public int CompletedDays { get; set; }
 
+    public string DaysProgress() => $"{CompletedDays} / {TargetDays.Count}";
+
     [JsonPropertyName("currentDay")]
     public DateOnly? CurrentDay { get; set; }
 
@@ -32,10 +34,13 @@ public class RunStatus
     [JsonPropertyName("currentDayProcessedFiles")]
     public int? CurrentDayProcessedFiles { get; set; }
 
-    public string CurrentDay
+    public string CurrentDayProgress() => $"{CurrentDayProcessedFiles} / {CurrentDayTotalFiles}";
 
     [JsonPropertyName("outputFilesCreated")]
     public int OutputFilesCreated { get; set; }
+
+    [JsonPropertyName("failedFilesCreated")]
+    public int FailedFilesCreated { get; set; }
 
     [JsonPropertyName("lastUpdated")]
     public DateTimeOffset LastUpdated { get; set; }

--- a/SendgridParquetViewer/Models/RunStatus.cs
+++ b/SendgridParquetViewer/Models/RunStatus.cs
@@ -18,4 +18,23 @@ public class RunStatus
 
     [JsonPropertyName("targetPaths")]
     public IList<string> TargetPathPrefixes { get; init; } = [];
+
+    // Progress fields (optional for backward compatibility)
+    [JsonPropertyName("completedDays")]
+    public int CompletedDays { get; set; }
+
+    [JsonPropertyName("currentDay")]
+    public DateOnly? CurrentDay { get; set; }
+
+    [JsonPropertyName("currentDayTotalFiles")]
+    public int? CurrentDayTotalFiles { get; set; }
+
+    [JsonPropertyName("currentDayProcessedFiles")]
+    public int? CurrentDayProcessedFiles { get; set; }
+
+    [JsonPropertyName("outputFilesCreated")]
+    public int OutputFilesCreated { get; set; }
+
+    [JsonPropertyName("lastUpdated")]
+    public DateTimeOffset LastUpdated { get; set; }
 }


### PR DESCRIPTION

概要

- 目的: Compaction 実行中の進行状況を RunStatus に逐次保存し、UIはサービスからのコールバックで即時反映（ポーリング
廃止）。
- 効果: 実行日単位の進捗、当日ファイル処理件数、生成済み出力数、最終更新時刻がUIにリアルタイム反映。S3書込頻度はバッチ単位、UIはサーバープッシュで可観測性とレスポンスを両立。

主な変更点

- RunStatus 拡張（後方互換の任意フィールド）
    - 追加: CompletedDays, CurrentDay, CurrentDayTotalFiles, CurrentDayProcessedFiles, OutputFilesCreated,
FailedFilesCreated, LastUpdated
    - 表示用ヘルパ: DaysProgress(), CurrentDayProgress()
- CompactionService の改善
    - API更新: StartCompactionAsync(Func<RunStatus?, Task> setRunStatus, CancellationToken ct = default) に変更し、実行
中にUIへプッシュ更新できるようにした
    - RunStatusContext を導入し、進捗保存（S3書込）とUI更新コールバックを一元化
    - 対象日の比較を包含条件に修正: dateOnly <= olderThanOrEqual（「この日付以前」）
    - バッチ入力を残ファイル集合に限定（再読込の無駄を削減）
    - 各バッチ終了時に CurrentDayProcessedFiles／OutputFilesCreated／FailedFilesCreated／LastUpdated を更新して保存
- UI（Compaction.razor）
    - ポーリング削除。サービスからの SetRunStatus コールバックで即時反映
    - Running 表示: Completed Days、Current Day、Day Progress、Output Files Created、Last Updated
    - リフレッシュボタンは手動更新用に残存

変更ファイル

- SendgridParquetViewer/Services/CompactionService.cs
- SendgridParquetViewer/Components/Pages/Compaction.razor
- SendgridParquetViewer/Models/RunStatus.cs

動作確認（推奨）

- /compaction を開き、Start → Running表示へ遷移し、進捗が逐次反映されること
- 1日分完了で CompletedDays が増加、各バッチで Day Progress と Output/Failed が増えること
- 終了時に Completed 表示へ遷移し、EndTime が記録されること
- 対象日抽出が「UTC基準の昨日まで（含む）」であること（境界: JST 9時またぎ）


- サーバープッシュ化: コールバックの導入によりUIは最新RunStatusを即反映。ポーリング削除は意図通り。呼び出し側は
SetRunStatus を非同期にし、InvokeAsync 経由で安全にState更新しておりOK。
- API変更の影響: CompactionService.StartCompactionAsync のシグネチャが変わっています。他の呼び出し元がないことを確認（現状、Pagesのみで使用）。将来の拡張では別オーバーロード提供も検討可。
- 対象日抽出: <= olderThanOrEqual で意図に合致。XMLコメントも「この日付以前」に揃っておりOK。
- バッチ入力: remainFiles を渡すよう修正済みで、I/Oの無駄が減って良いです。
- S3書込頻度: バッチごと保存は十分だが、データ量によっては書込頻度が高くなる可能性あり。必要ならスロットリング（例: 最終更新からN秒以上で保存）を検討。
- 失敗計測: FailedFilesCreated をRunStatusに反映しており、失敗件数の可視化が可能。日単位の失敗要約（例: 失敗ファイルのパス一覧は別ログに任せ、件数のみRunStatus）でバランス良し。
- UIの微調整候補: FluentMessageBar の OnDismiss が message を参照しているため、_message に合わせて () => _message =
string.Empty へ修正を推奨（軽微）。

リスクとロールバック

- 影響範囲はCompactionの内部APIとUIのみ。問題があれば StartCompactionAsync の旧シグネチャ互換オーバーロードを暫定追加し
て段階移行も可能。
- 進捗保存の頻度を抑えるロールバックは RunStatusContext.SaveRunStatusAsync 呼び出し箇所を日単位の完了時に限定すれば
容易。