### PR TITLE
refactor(shared): Parquet 列読み取りの重複削除と CancellationToken の一貫適用

### DIFF
--- a/SendgridParquet.Shared/ParquetService.cs
+++ b/SendgridParquet.Shared/ParquetService.cs
@@ -177,36 +177,36 @@ public class ParquetService
     {
         ParquetSchema schema = parquetReader.Schema;
         // Read required columns safely (if missing or read fails, yield no rows)
-        var emailColumn = await TryReadRequiredColumnAsync(rowGroupReader, schema, SendGridWebHookFields.Email, token);
+        var emailColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.Email, token);
         if (emailColumn is null) yield break;
-        var timestampColumn = await TryReadRequiredColumnAsync(rowGroupReader, schema, SendGridWebHookFields.Timestamp, token);
+        var timestampColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.Timestamp, token);
         if (timestampColumn is null) yield break;
-        var eventColumn = await TryReadRequiredColumnAsync(rowGroupReader, schema, SendGridWebHookFields.Event, token);
+        var eventColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.Event, token);
         if (eventColumn is null) yield break;
 
         // Get optional columns
-        var categoryColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.Category);
-        var sgEventIdColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.SgEventId);
-        var sgMessageIdColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.SgMessageId);
-        var sgTemplateIdColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.SgTemplateId);
-        var smtpIdColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.SmtpIdParquetColumn);
-        var userAgentColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.UserAgent);
-        var ipColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.Ip);
-        var urlColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.Url);
-        var reasonColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.Reason);
-        var statusColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.Status);
-        var responseColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.Response);
-        var tlsColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.Tls);
-        var attemptColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.Attempt);
-        var typeColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.Type);
-        var bounceClassificationColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.BounceClassification);
-        var asmGroupIdColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.AsmGroupId);
-        //var uniqueArgsColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.UniqueArgs);
-        var marketingCampaignIdColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.MarketingCampaignId);
-        var marketingCampaignNameColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.MarketingCampaignName);
-        var poolNameColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.PoolNameParquetColumn);
-        var poolIdColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.PoolIdParquetColumn);
-        var sendAtColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.SendAt);
+        var categoryColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.Category, token);
+        var sgEventIdColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.SgEventId, token);
+        var sgMessageIdColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.SgMessageId, token);
+        var sgTemplateIdColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.SgTemplateId, token);
+        var smtpIdColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.SmtpIdParquetColumn, token);
+        var userAgentColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.UserAgent, token);
+        var ipColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.Ip, token);
+        var urlColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.Url, token);
+        var reasonColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.Reason, token);
+        var statusColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.Status, token);
+        var responseColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.Response, token);
+        var tlsColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.Tls, token);
+        var attemptColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.Attempt, token);
+        var typeColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.Type, token);
+        var bounceClassificationColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.BounceClassification, token);
+        var asmGroupIdColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.AsmGroupId, token);
+        //var uniqueArgsColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.UniqueArgs, token);
+        var marketingCampaignIdColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.MarketingCampaignId, token);
+        var marketingCampaignNameColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.MarketingCampaignName, token);
+        var poolNameColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.PoolNameParquetColumn, token);
+        var poolIdColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.PoolIdParquetColumn, token);
+        var sendAtColumn = await TryReadColumnAsync(rowGroupReader, schema, SendGridWebHookFields.SendAt, token);
 
         int rowCount = emailColumn.Data.Length;
         for (int idx = 0; idx < rowCount; idx++)
@@ -245,29 +245,12 @@ public class ParquetService
         }
     }
 
-    private async Task<DataColumn?> TryReadColumnAsync(ParquetRowGroupReader rowGroupReader, ParquetSchema schema, string fieldName)
+    private async Task<DataColumn?> TryReadColumnAsync(ParquetRowGroupReader rowGroupReader, ParquetSchema schema, string fieldName, CancellationToken token)
     {
         try
         {
             DataField? field = schema.GetDataFields().FirstOrDefault(f => f.Name == fieldName);
-            return field == null ? null : await rowGroupReader.ReadColumnAsync(field);
-        }
-        catch
-        {
-            return null;
-        }
-    }
-
-    private async Task<DataColumn?> TryReadRequiredColumnAsync(ParquetRowGroupReader rowGroupReader, ParquetSchema schema, string fieldName, CancellationToken token)
-    {
-        try
-        {
-            DataField? field = schema.GetDataFields().FirstOrDefault(f => f.Name == fieldName);
-            if (field == null)
-            {
-                return null;
-            }
-            return await rowGroupReader.ReadColumnAsync(field, token);
+            return field == null ? null : await rowGroupReader.ReadColumnAsync(field, token);
         }
         catch
         {


### PR DESCRIPTION
- 説明:
    - 変更点:
    - `TryReadRequiredColumnAsync` を `TryReadColumnAsync(..., CancellationToken)` に統合
    - 全ての列読み取りで `CancellationToken` を受け渡すよう修正（必須/任意カラム）
    - 例外/列欠落時は `null` を返す現行仕様を維持（呼び出し側で制御）
- 背景:
    - 同等実装の重複を解消して保守性を向上
    - 長時間 I/O のキャンセル応答性を確保
- 影響範囲:
    - 内部実装のみ。公開 API 変更なし。機能的な挙動は不変
- リスク/対応:
    - 列読み取り失敗の理由は引き続き握りつぶし。必要ならログ追加や、必須列欠落時の明示的エラー化を後続で検討
- テスト:
    - 必須/任意カラムの欠落ケース、キャンセル発火の挙動を手元で確認予定
- チェックリスト:
    - [ ] ビルドが通ることを確認
    - [ ] 欠落カラム/キャンセルのユースケース確認
    - [ ] 追加のログ要否をレビュー