### PR TITLE
Add OpenTelemetry with conditional OTLP/Azure Monitor exporters and ignore docs in deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - README.md
+      - CLAUDE.md
+      - LICENSE
   workflow_dispatch:
 
 env:

--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ ASP.NET Core のOptions パターンを使用して設定を管理します。
 | SENDGRID__VERIFICATIONKEY | SendGrid Event Webhook 検証用公開鍵 (PEM または Base64(SPKI)) | -----BEGIN PUBLIC KEY----- ... |
 | SENDGRID__MAXBODYBYTES | Webhook リクエストボディ上限 (バイト) | 1048576 |
 | SENDGRID__ALLOWEDSKEW | タイムスタンプ許容スキュー (TimeSpan.Parse 形式) | 00:05:00 |
+| OTEL_EXPORTER_OTLP_ENDPOINT | OpenTelemetry OTLP エンドポイントURL | http://localhost:4318 |
+| OTEL_EXPORTER_OTLP_PROTOCOL | OTLP プロトコル (`grpc`/`http/protobuf`) | http/protobuf |
+| OTEL_EXPORTER_OTLP_HEADERS | OTLP 追加ヘッダー（`k=v,k2=v2` 形式） | x-api-key=xxxxx |
+
+補足: `.NET Aspire` のローカル開発時は `DOTNET_DASHBOARD_OTLP_ENDPOINT_URL`（ダッシュボードの OTLP URL）が設定される場合があり、`OTEL_EXPORTER_OTLP_ENDPOINT` が未設定でも自動的にそれを利用してメトリクス/トレース/ログを送信します。いずれの接続先情報も未設定の場合は OpenTelemetry の「送信」は行われません（計測は有効）。
 
 ### appsettings.json での設定
 

--- a/SendgridParquetLog.ServiceDefaults/Extensions.cs
+++ b/SendgridParquetLog.ServiceDefaults/Extensions.cs
@@ -8,6 +8,7 @@ using OpenTelemetry;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Trace;
+using Azure.Monitor.OpenTelemetry.AspNetCore;
 
 namespace Microsoft.Extensions.Hosting;
 
@@ -101,12 +102,11 @@ public static class Extensions
             builder.Services.AddOpenTelemetry().UseOtlpExporter(protocol, uri);
         }
 
-        // Uncomment the following lines to enable the Azure Monitor exporter (requires the Azure.Monitor.OpenTelemetry.AspNetCore package)
-        //if (!string.IsNullOrEmpty(builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]))
-        //{
-        //    builder.Services.AddOpenTelemetry()
-        //       .UseAzureMonitor();
-        //}
+        // Enable the Azure Monitor exporter when connection string is provided
+        if (!string.IsNullOrWhiteSpace(builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]))
+        {
+            builder.Services.AddOpenTelemetry().UseAzureMonitor();
+        }
 
         return builder;
     }

--- a/SendgridParquetLog.ServiceDefaults/Extensions.cs
+++ b/SendgridParquetLog.ServiceDefaults/Extensions.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Exporter;
 using OpenTelemetry.Trace;
 
 namespace Microsoft.Extensions.Hosting;
@@ -71,11 +72,33 @@ public static class Extensions
 
     private static IHostApplicationBuilder AddOpenTelemetryExporters(this IHostApplicationBuilder builder)
     {
-        var useOtlpExporter = !string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
-
-        if (useOtlpExporter)
+        var endpoint = builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"];
+        var fromDashboard = false;
+        if (string.IsNullOrWhiteSpace(endpoint))
         {
-            builder.Services.AddOpenTelemetry().UseOtlpExporter();
+            // Fallback for .NET Aspire Dashboard local dev
+            endpoint = builder.Configuration["DOTNET_DASHBOARD_OTLP_ENDPOINT_URL"];
+            fromDashboard = !string.IsNullOrWhiteSpace(endpoint);
+        }
+
+        if (!string.IsNullOrWhiteSpace(endpoint))
+        {
+            var uri = new Uri(endpoint);
+            var protoEnv = builder.Configuration["OTEL_EXPORTER_OTLP_PROTOCOL"];
+            var protocol = OtlpExportProtocol.Grpc;
+            if (!string.IsNullOrWhiteSpace(protoEnv))
+            {
+                protocol = protoEnv.Equals("http/protobuf", StringComparison.OrdinalIgnoreCase)
+                    ? OtlpExportProtocol.HttpProtobuf
+                    : OtlpExportProtocol.Grpc;
+            }
+            else if (fromDashboard || uri.Scheme.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+            {
+                protocol = OtlpExportProtocol.HttpProtobuf;
+            }
+
+            // Use overload compatible with OpenTelemetry 1.12.0
+            builder.Services.AddOpenTelemetry().UseOtlpExporter(protocol, uri);
         }
 
         // Uncomment the following lines to enable the Azure Monitor exporter (requires the Azure.Monitor.OpenTelemetry.AspNetCore package)

--- a/SendgridParquetLog.ServiceDefaults/SendgridParquetLog.ServiceDefaults.csproj
+++ b/SendgridParquetLog.ServiceDefaults/SendgridParquetLog.ServiceDefaults.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.3.0" />
   </ItemGroup>
 
 </Project>

--- a/SendgridParquetViewer/Program.cs
+++ b/SendgridParquetViewer/Program.cs
@@ -12,7 +12,12 @@ using SendgridParquetViewer.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
-#if DEBUG // 認証機能については 安全のため Release ビルドで明示的に無効化された状態にする
+#if UseAspire
+// Add Aspire service defaults (service discovery, health checks, OpenTelemetry)
+builder.AddServiceDefaults();
+#endif
+
+#if DEBUG // Dev認証機能については 安全のため Release ビルドで明示的に無効化された状態にする
 var azureAdSection = builder.Configuration.GetSection("AzureAd");
 if (string.IsNullOrEmpty(azureAdSection.GetValue<string>("Instance")))
 {
@@ -131,5 +136,10 @@ app.MapControllers();
 
 // Map health check endpoint (allow anonymous access)
 app.MapHealthChecks("/health6QQl").AllowAnonymous();
+
+#if UseAspire
+// Map Aspire default endpoints (health checks etc. in dev)
+app.MapDefaultEndpoints();
+#endif
 
 app.Run();

--- a/SendgridParquetViewer/SendgridParquetViewer.csproj
+++ b/SendgridParquetViewer/SendgridParquetViewer.csproj
@@ -20,4 +20,13 @@
     <ProjectReference Include="../SendgridParquet.Shared/SendgridParquet.Shared.csproj" />
   </ItemGroup>
 
+  <!-- Aspire はデバッグビルドのみ有効 -->
+  <ItemGroup Condition="'$(Configuration)' == 'Debug'">
+    <ProjectReference Include="../SendgridParquetLog.ServiceDefaults/SendgridParquetLog.ServiceDefaults.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <DefineConstants>UseAspire;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
- 概要:
    - OpenTelemetry 計測を ServiceDefaults で有効化し、送信は環境変数により条件化（本番で未設定なら送信しない）。
    - デプロイワークフロートリガーからドキュメントのみの変更を除外。
- 変更点:
    - SendgridParquetLog.ServiceDefaults/Extensions.cs
    - OTLP: `OTEL_EXPORTER_OTLP_ENDPOINT`→なければ`DOTNET_DASHBOARD_OTLP_ENDPOINT_URL`を使用
    - プロトコル自動判定（`OTEL_EXPORTER_OTLP_PROTOCOL` 優先、未指定かつ http/https は `http/protobuf`）
    - Azure Monitor: `APPLICATIONINSIGHTS_CONNECTION_STRING` があれば `UseAzureMonitor()` を有効化
    - ログ/Metrics/Trace の基本計測を追加（AspNetCore/HttpClient/Runtime）
- SendgridParquetViewer/SendgridParquetViewer.csproj:
    - Debug 構成で ServiceDefaults を参照、`UseAspire` 定義
- SendgridParquetViewer/Program.cs:
    - Debug 時に `builder.AddServiceDefaults()` と `app.MapDefaultEndpoints()` を追加
- .github/workflows/deploy.yml:
    - `paths-ignore`: `README.md`, `CLAUDE.md`, `LICENSE`
- README.md:
    - OTLP 関連環境変数を追記（エンドポイント未設定時は送信しない旨を明記）

- 環境変数（運用ポイント）:
    - OTEL_EXPORTER_OTLP_ENDPOINT（例: http://localhost:4318）
    - OTEL_EXPORTER_OTLP_PROTOCOL（grpc / http/protobuf）
    - OTEL_EXPORTER_OTLP_HEADERS（任意）
    - DOTNET_DASHBOARD_OTLP_ENDPOINT_URL（Aspire ローカル開発時）
    - APPLICATIONINSIGHTS_CONNECTION_STRING（Azure Monitor）
    - いずれも未設定ならエクスポータ未登録（送信なし）

- 動作確認:
    - ローカル（Aspire）: DOTNET_DASHBOARD_OTLP_ENDPOINT_URL があれば Dashboard にメトリクス/ログ/トレースが可視化される
    - OTLP: OTEL_EXPORTER_OTLP_ENDPOINT を指定し、収集先（OTel Collector 等）で受信確認
    - Azure Monitor: APPLICATIONINSIGHTS_CONNECTION_STRING を指定し、メトリクス/ログ/トレースが届くことを確認
    - ビルド: dotnet build 成功
- リスク/移行:
    - テレメトリ送信は環境変数未設定なら無効化のため既存挙動への影響は最小
    - Viewer は Debug 時のみ Aspire 設定が有効（本番で計測を有効化したい場合は別 PR で切替）
- フォローアップ（任意）:
    - README に APPLICATIONINSIGHTS_CONNECTION_STRING を追記
    - Resource（service.name, service.version, デプロイ環境タグ）とサンプリング設定の追加
    - CI にテスト・lint・OTel の最小スモークチェック追加
    - deploy.yml の paths-ignore 拡張（**/*.md など）検討