### PR TITLE
コンパクション時のメモリ削減: Parquet 逐次列化と行グループ出力の導入

### DIFF
--- a/SendgridParquet.Shared/ParquetService.cs
+++ b/SendgridParquet.Shared/ParquetService.cs
@@ -200,7 +200,10 @@ public class ParquetService
             return;
         }
 
-        using ParquetRowGroupWriter groupWriter = writer.CreateRowGroup(rowCount);
+        // CreateRowGroup() メソッドに行数を指定する引数はありません。
+        // 行グループの行数 (rowCount) は、WriteColumn() で書き込む配列の要素数で決まります
+        // 複数の行グループを作成したい場合は、CreateRowGroup() の呼び出しとデータ書き込みの処理をループで繰り返します。
+        using ParquetRowGroupWriter groupWriter = writer.CreateRowGroup();
         foreach (var buffer in buffers)
         {
             var column = buffer.BuildDataColumn();

--- a/SendgridParquet.Shared/ParquetService.cs
+++ b/SendgridParquet.Shared/ParquetService.cs
@@ -13,10 +13,53 @@ namespace SendgridParquet.Shared;
 
 public class ParquetService
 {
+    private const int DefaultRowGroupSize = 10_000;
+
     // Paired field definition and processing function
-    private record FieldProcessor(DataField Field, Func<IEnumerable<SendGridEvent>, DataColumn> ProcessorFunc);
+    private record FieldProcessor(
+        DataField Field,
+        Func<IEnumerable<SendGridEvent>, DataColumn> ProcessorFunc,
+        Func<int, IColumnBuffer> BufferFactory);
+
+    private interface IColumnBuffer
+    {
+        int Count { get; }
+
+        void Append(SendGridEvent item);
+
+        DataColumn BuildDataColumn();
+
+        void Clear();
+    }
+
+    private sealed class ColumnBuffer<T> : IColumnBuffer
+    {
+        private readonly DataField _field;
+        private readonly Func<SendGridEvent, T> _selector;
+        private readonly List<T> _values;
+
+        internal ColumnBuffer(DataField field, int capacity, Func<SendGridEvent, T> selector)
+        {
+            _field = field;
+            _selector = selector;
+            _values = new List<T>(capacity);
+        }
+
+        public int Count => _values.Count;
+
+        public void Append(SendGridEvent item) => _values.Add(_selector(item));
+
+        public DataColumn BuildDataColumn() => new(_field, _values.ToArray());
+
+        public void Clear() => _values.Clear();
+    }
 
     private static readonly FieldProcessor[] FieldProcessors = CreateFieldProcessors();
+
+    private static FieldProcessor CreateFieldProcessor<T>(DataField field, Func<SendGridEvent, T> selector)
+        => new(field,
+            events => new DataColumn(field, events.Select(selector).ToArray()),
+            capacity => new ColumnBuffer<T>(field, capacity, selector));
 
     private static FieldProcessor[] CreateFieldProcessors()
     {
@@ -49,105 +92,32 @@ public class ParquetService
 
         return
         [
-            new FieldProcessor(emailField,
-                events => new DataColumn(emailField,
-                    events.Select(e => e.Email ?? string.Empty).ToArray())),
-
-            new FieldProcessor(timestampField,
-                events => new DataColumn(timestampField,
-                    events.Select(e => e.Timestamp).ToArray())),
-
-            new FieldProcessor(eventField,
-                events => new DataColumn(eventField,
-                    events.Select(e => e.Event ?? string.Empty).ToArray())),
-
-            new FieldProcessor(categoryField,
-                events => new DataColumn(categoryField,
-                    events.Select(e => e.Category ?? string.Empty).ToArray())),
-
-            new FieldProcessor(sgEventIdField,
-                events => new DataColumn(sgEventIdField,
-                    events.Select(e => e.SgEventId ?? string.Empty).ToArray())),
-
-            new FieldProcessor(sgMessageIdField,
-                events => new DataColumn(sgMessageIdField,
-                    events.Select(e => e.SgMessageId ?? string.Empty).ToArray())),
-
-            new FieldProcessor(sgTemplateIdField,
-                events => new DataColumn(sgTemplateIdField,
-                    events.Select(e => e.SgTemplateId ?? string.Empty).ToArray())),
-
-            new FieldProcessor(smtpIdField,
-                events => new DataColumn(smtpIdField,
-                    events.Select(e => e.SmtpId ?? string.Empty).ToArray())),
-
-            new FieldProcessor(userAgentField,
-                events => new DataColumn(userAgentField,
-                    events.Select(e => e.UserAgent ?? string.Empty).ToArray())),
-
-            new FieldProcessor(ipField,
-                events => new DataColumn(ipField,
-                    events.Select(e => e.Ip ?? string.Empty).ToArray())),
-
-            new FieldProcessor(urlField,
-                events => new DataColumn(urlField,
-                    events.Select(e => e.Url ?? string.Empty).ToArray())),
-
-            new FieldProcessor(reasonField,
-                events => new DataColumn(reasonField,
-                    events.Select(e => e.Reason ?? string.Empty).ToArray())),
-
-            new FieldProcessor(statusField,
-                events => new DataColumn(statusField,
-                    events.Select(e => e.Status ?? string.Empty).ToArray())),
-
-            new FieldProcessor(responseField,
-                events => new DataColumn(responseField,
-                    events.Select(e => e.Response ?? string.Empty).ToArray())),
-
-            new FieldProcessor(tlsField,
-                events => new DataColumn(tlsField,
-                    events.Select(e => e.Tls).ToArray())),
-
-            new FieldProcessor(attemptField,
-                events => new DataColumn(attemptField,
-                    events.Select(e => e.Attempt ?? string.Empty).ToArray())),
-
-            new FieldProcessor(typeField,
-                events => new DataColumn(typeField,
-                    events.Select(e => e.Type ?? string.Empty).ToArray())),
-
-            new FieldProcessor(bounceClassificationField,
-                events => new DataColumn(bounceClassificationField,
-                    events.Select(e => e.BounceClassification ?? string.Empty).ToArray())),
-
-            new FieldProcessor(asmGroupIdField,
-                events => new DataColumn(asmGroupIdField,
-                    events.Select(e => e.AsmGroupId).ToArray())),
-
-            //new FieldProcessor(uniqueArgsField,
-            //    events => new DataColumn(uniqueArgsField,
-            //        events.Select(e => e.UniqueArgs.HasValue ? e.UniqueArgs.Value.GetRawText() : string.Empty).ToArray())),
-
-            new FieldProcessor(marketingCampaignIdField,
-                events => new DataColumn(marketingCampaignIdField,
-                    events.Select(e => e.MarketingCampaignId).ToArray())),
-
-            new FieldProcessor(marketingCampaignNameField,
-                events => new DataColumn(marketingCampaignNameField,
-                    events.Select(e => e.MarketingCampaignName ?? string.Empty).ToArray())),
-
-            new FieldProcessor(poolNameField,
-                events => new DataColumn(poolNameField,
-                    events.Select(e => e.Pool?.Name ?? string.Empty).ToArray())),
-
-            new FieldProcessor(poolIdField,
-                events => new DataColumn(poolIdField,
-                    events.Select(e => e.Pool?.Id).ToArray())),
-
-            new FieldProcessor(sendAtField,
-                events => new DataColumn(sendAtField,
-                    events.Select(e => e.SendAt).ToArray()))
+            CreateFieldProcessor(emailField, e => e.Email ?? string.Empty),
+            CreateFieldProcessor(timestampField, e => e.Timestamp),
+            CreateFieldProcessor(eventField, e => e.Event ?? string.Empty),
+            CreateFieldProcessor(categoryField, e => e.Category ?? string.Empty),
+            CreateFieldProcessor(sgEventIdField, e => e.SgEventId ?? string.Empty),
+            CreateFieldProcessor(sgMessageIdField, e => e.SgMessageId ?? string.Empty),
+            CreateFieldProcessor(sgTemplateIdField, e => e.SgTemplateId ?? string.Empty),
+            CreateFieldProcessor(smtpIdField, e => e.SmtpId ?? string.Empty),
+            CreateFieldProcessor(userAgentField, e => e.UserAgent ?? string.Empty),
+            CreateFieldProcessor(ipField, e => e.Ip ?? string.Empty),
+            CreateFieldProcessor(urlField, e => e.Url ?? string.Empty),
+            CreateFieldProcessor(reasonField, e => e.Reason ?? string.Empty),
+            CreateFieldProcessor(statusField, e => e.Status ?? string.Empty),
+            CreateFieldProcessor(responseField, e => e.Response ?? string.Empty),
+            CreateFieldProcessor(tlsField, e => e.Tls),
+            CreateFieldProcessor(attemptField, e => e.Attempt ?? string.Empty),
+            CreateFieldProcessor(typeField, e => e.Type ?? string.Empty),
+            CreateFieldProcessor(bounceClassificationField, e => e.BounceClassification ?? string.Empty),
+            CreateFieldProcessor(asmGroupIdField, e => e.AsmGroupId),
+            //CreateFieldProcessor(uniqueArgsField,
+            //    e => e.UniqueArgs.HasValue ? e.UniqueArgs.Value.GetRawText() : string.Empty),
+            CreateFieldProcessor(marketingCampaignIdField, e => e.MarketingCampaignId),
+            CreateFieldProcessor(marketingCampaignNameField, e => e.MarketingCampaignName ?? string.Empty),
+            CreateFieldProcessor(poolNameField, e => e.Pool?.Name ?? string.Empty),
+            CreateFieldProcessor(poolIdField, e => e.Pool?.Id),
+            CreateFieldProcessor(sendAtField, e => e.SendAt)
         ];
     }
 
@@ -167,6 +137,76 @@ public class ParquetService
             await groupWriter.WriteColumnAsync(dataColumn);
         }
         return true;
+    }
+
+    public async Task<bool> ConvertToParquetStreamingAsync(
+        IAsyncEnumerable<SendGridEvent> events,
+        Stream stream,
+        int rowGroupSize = DefaultRowGroupSize,
+        CancellationToken token = default)
+    {
+        ArgumentNullException.ThrowIfNull(events);
+        ArgumentNullException.ThrowIfNull(stream);
+
+        if (rowGroupSize <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(rowGroupSize));
+        }
+
+        Field[] fields = FieldProcessors.Select(fp => fp.Field).ToArray<Field>();
+        await using var writer = await ParquetWriter.CreateAsync(new ParquetSchema(fields), stream, cancellationToken: token);
+        IColumnBuffer[] buffers = FieldProcessors
+            .Select(fp => fp.BufferFactory(rowGroupSize))
+            .ToArray();
+
+        bool hasData = false;
+        await foreach (var sendGridEvent in events.WithCancellation(token))
+        {
+            hasData = true;
+            foreach (var buffer in buffers)
+            {
+                buffer.Append(sendGridEvent);
+            }
+
+            if (buffers[0].Count >= rowGroupSize)
+            {
+                await WriteRowGroupAsync(writer, buffers);
+            }
+        }
+
+        if (!hasData)
+        {
+            return false;
+        }
+
+        if (buffers[0].Count > 0)
+        {
+            await WriteRowGroupAsync(writer, buffers);
+        }
+
+        return true;
+    }
+
+    private static async Task WriteRowGroupAsync(ParquetWriter writer, IColumnBuffer[] buffers)
+    {
+        if (buffers.Length == 0)
+        {
+            return;
+        }
+
+        int rowCount = buffers[0].Count;
+        if (rowCount == 0)
+        {
+            return;
+        }
+
+        using ParquetRowGroupWriter groupWriter = writer.CreateRowGroup(rowCount);
+        foreach (var buffer in buffers)
+        {
+            var column = buffer.BuildDataColumn();
+            await groupWriter.WriteColumnAsync(column);
+            buffer.Clear();
+        }
     }
 
     public async IAsyncEnumerable<SendGridEvent> ReadRowGroupEventsAsync(

--- a/SendgridParquetLogger/Helper/WebhookHelper.cs
+++ b/SendgridParquetLogger/Helper/WebhookHelper.cs
@@ -135,7 +135,7 @@ public class WebhookHelper(
         CancellationToken ct)
     {
         var events = eventsEnumerable.ToArray();
-        await using var parquetData = new MemoryStream();
+        await using var parquetData = new MemoryStream(); // WebHook は 最大 768KB でしか来ないのでメモリ上に展開する
         bool convertResult = await parquetService.ConvertToParquetAsync(events, parquetData);
         if (!convertResult)
         {

--- a/SendgridParquetViewer/Services/CompactionStartupHostedService.cs
+++ b/SendgridParquetViewer/Services/CompactionStartupHostedService.cs
@@ -4,14 +4,14 @@ public sealed class CompactionStartupHostedService(
     CompactionService compactionService
 ) : IHostedService, IAsyncDisposable
 {
-    public async Task StartAsync(CancellationToken cancellationToken)
+    public async Task StartAsync(CancellationToken ct)
     {
-        await compactionService.StartCompactionAsync(cancellationToken);
+        await compactionService.StartCompactionAsync(ct);
     }
 
-    public async Task StopAsync(CancellationToken cancellationToken)
+    public async Task StopAsync(CancellationToken ct)
     {
-        await compactionService.StopCompactionAsync(cancellationToken);
+        await compactionService.StopCompactionAsync(ct);
     }
 
     public async ValueTask DisposeAsync()

--- a/SendgridParquetViewer/Services/DisposableTempFile.cs
+++ b/SendgridParquetViewer/Services/DisposableTempFile.cs
@@ -12,7 +12,7 @@ public static class DisposableTempFile
             BufferSize,
             options: FileOptions.DeleteOnClose);
 
-    private static readonly HashSet<char> s_invalidChars =  Path.GetInvalidFileNameChars().ToHashSet();
+    private static readonly HashSet<char> s_invalidChars = Path.GetInvalidFileNameChars().ToHashSet();
 
     private static string GetPath(string filename)
     {


### PR DESCRIPTION
## 概要
高トラフィック時間帯のコンパクションで発生していたメモリスパイクを抑制するため、イベントを逐次列化しつつ、行グループ単位で Parquet へ書き出すストリーミング方式へ変更しました。従来の「1時間内の全イベントを `List<SendGridEvent>` に集約 → 一括変換」を廃止し、臨時ファイルからの逐次読み出しで `RowGroupSize` ごとにフラッシュします。

Webhook 側の変換 API は従来通り維持しています。

## 主な変更点
- SendgridParquet.Shared
  - `SendgridParquet.Shared/ParquetService.cs`
    - 列バッファ実装（`IColumnBuffer`/`ColumnBuffer<T>`）を追加。
    - ストリーミング変換 API `ConvertToParquetStreamingAsync(IAsyncEnumerable<SendGridEvent> ...)` を追加。
    - 既存の `FieldProcessors` を拡張し、ストリーミング用 `BufferFactory` を導入。
    - Parquet バージョンに合わせ、`CreateRowGroup()` は引数なし呼び出しを使用。
- SendgridParquetViewer
  - `SendgridParquetViewer/Services/CompactionService.cs`
    - 1時間グループ出力での `List<SendGridEvent>` 集約を廃止し、`EnumeratePackedEventsAsync(...)` で逐次列挙 → `ConvertToParquetStreamingAsync(...)` に渡す形へ変更。
    - `RowGroupSize = 200_000` を導入（環境に応じて調整推奨）。
    - ログは1時間グループのイベント数に基づいて出力。
  - `SendgridParquetViewer/Services/CompactionStartupHostedService.cs` / `SendgridParquetViewer/Services/S3LockService.cs`
    - 引数名を `ct` に統一（可読性改善のみ）。
  - `SendgridParquetViewer/Services/DisposableTempFile.cs`
    - スタイル修正のみ。
- SendgridParquetLogger
  - `SendgridParquetLogger/Helper/WebhookHelper.cs`
    - コメント追記（挙動変更なし）。

## 効果
- メモリピークが「1時間の全イベントを一括保持」から「行グループ分（`RowGroupSize` 分）のみ」に大幅縮小。
- コンパクションのメモリプロファイルが平準化され、ピーク時の安定性が向上。

## 互換性
- Parquet スキーマの互換性は維持されます。行グループの切り方は変更される可能性がありますが、一般的に下流互換です。
- ランタイム要件や外部 I/F（S3 パス等）の変更はありません。

## 既知の制約 / フォローアップ
- 一時ファイルはファイル単位で `SendGridEvent[]` を Deserialize しているため、1ファイルが巨大な場合のピークは残ります。
  - 将来的に「一時ファイルの分割書き出し」または「ストリーミングデシリアライズ」へ拡張予定。
- `RowGroupSize` は現時点で定数（`CompactionService` 内）。`CompactionOptions` に設定化して運用で調整可能にすることを推奨します。
- 行グループ内では列ごとの `ToArray()` が発生するため、`RowGroupSize` を大きくし過ぎると逆にメモリが増える可能性があります。

## テスト / 検証
- ビルドは通過（環境により MSBuild named pipe が使用不可の場合、`dotnet test` が失敗することがあります。ローカル環境でのテスト実行をお願いします）。
- 実データでのコンパクション実行時に、以下の観測をお願いします:
  - メモリピーク/常時メモリ使用量の推移
  - 行グループ数と出力ファイルの整合性（Verify ログ）
  - 1時間グループのイベント数が 0 のケースでのスキップ動作

## レビュー観点
- `RowGroupSize` の妥当性（初期値 200,000）。まずは 50,000〜100,000 程度から開始し、実測で最適化する方針を推奨。
- ログ/メトリクスの拡充（行グループごとの処理時間、行グループ数、失敗時の詳細）が必要かどうか。
- 将来の「一時ファイル分割」または「ストリーミングデシリアライズ」に向けたインターフェース設計の柔軟性。

## 変更ファイル（抜粋）
- `SendgridParquet.Shared/ParquetService.cs`
- `SendgridParquetViewer/Services/CompactionService.cs`
- `SendgridParquetViewer/Services/CompactionStartupHostedService.cs`
- `SendgridParquetViewer/Services/DisposableTempFile.cs`
- `SendgridParquetViewer/Services/S3LockService.cs`
- `SendgridParquetLogger/Helper/WebhookHelper.cs`

## チェックリスト
- [x] メモリ削減の主要経路（1時間グループのリスト化）を廃止
- [x] 逐次列化＋行グループ出力の導入
- [x] 既存 API の互換維持（Webhook 側）
- [ ] `RowGroupSize` の設定化（フォローアップ）
- [ ] 一時ファイルの分割 or ストリーミングデシリアライズ対応の検討（フォローアップ）
