### PR TITLE
viewer: コンパクションの定期実行（日次）と起動ノンブロッキング化、重複起動ガードの追加

### DIFF
--- a/SendgridParquetViewer/Services/CompactionService.cs
+++ b/SendgridParquetViewer/Services/CompactionService.cs
@@ -80,6 +80,12 @@ public class CompactionService(
         await _startupTaskSemaphore.WaitAsync(ct);
         try
         {
+            var isCompleted = _compactionStartResult?.StartTask?.IsCompleted;
+            if (_compactionStartResult != null && isCompleted != true)
+            {
+                return _compactionStartResult;
+            }
+            // 開始の指示に対しては Faulted, Cancelled でも再開する
             return await StartCompactionAsyncInLock(ct);
         }
         finally
@@ -178,6 +184,7 @@ public class CompactionService(
                 {
                     await task;
                 }
+                _compactionStartResult = null; // 前回開始時間を UI でフィードバックする場合は Start 時点の返り値を受け取った側が管理する
             }
             _startupCancellation?.Dispose();
             _startupCancellation = null;

--- a/SendgridParquetViewer/Services/CompactionService.cs
+++ b/SendgridParquetViewer/Services/CompactionService.cs
@@ -80,8 +80,8 @@ public class CompactionService(
         await _startupTaskSemaphore.WaitAsync(ct);
         try
         {
-            var isCompleted = _compactionStartResult?.StartTask?.IsCompleted;
-            if (_compactionStartResult != null && isCompleted != true)
+            var isTaskRunning = _compactionStartResult?.StartTask != null && !_compactionStartResult.StartTask.IsCompleted;
+            if (isTaskRunning)
             {
                 return _compactionStartResult;
             }

--- a/SendgridParquetViewer/Services/CompactionStartupHostedService.cs
+++ b/SendgridParquetViewer/Services/CompactionStartupHostedService.cs
@@ -1,16 +1,48 @@
-﻿namespace SendgridParquetViewer.Services;
+﻿using System.Diagnostics;
+
+using SendgridParquetViewer.Models;
+
+namespace SendgridParquetViewer.Services;
 
 public sealed class CompactionStartupHostedService(
     CompactionService compactionService
 ) : IHostedService, IAsyncDisposable
 {
-    public async Task StartAsync(CancellationToken ct)
+    private readonly TimeSpan _periodicSpan = TimeSpan.FromDays(1);
+    private CancellationTokenSource? _cts;
+    private CompactionStartResult? _compactionStartResult;
+
+    public Task StartAsync(CancellationToken ct)
     {
-        await compactionService.StartCompactionAsync(ct);
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        _ = Task.Run(async () =>
+        {
+            Stopwatch stopwatch = new();
+            do
+            {
+                stopwatch.Restart();
+                _compactionStartResult = await compactionService.StartCompactionAsync(ct);
+                if (_compactionStartResult?.StartTask != null)
+                {
+                    await _compactionStartResult.StartTask;
+                }
+
+                TimeSpan elapsed = stopwatch.Elapsed;
+                if (elapsed < _periodicSpan)
+                {
+                    await Task.Delay(elapsed - _periodicSpan, _cts.Token);
+                }
+            } while (!_cts.IsCancellationRequested);
+        }, _cts.Token);
+        return Task.CompletedTask;
     }
 
     public async Task StopAsync(CancellationToken ct)
     {
+        if (_cts != null)
+        {
+            await _cts.CancelAsync();
+        }
         await compactionService.StopCompactionAsync(ct);
     }
 

--- a/SendgridParquetViewer/Services/CompactionStartupHostedService.cs
+++ b/SendgridParquetViewer/Services/CompactionStartupHostedService.cs
@@ -13,7 +13,7 @@ public sealed class CompactionStartupHostedService(
 
     private async Task Run(CancellationToken ct)
     {
-        logger.ZLogInformation($"CompactionStartupHostedService Run");
+        logger.ZLogInformation($"Starting compaction process in CompactionStartupHostedService.");
         try
         {
             var compactionStartResult = await compactionService.StartCompactionAsync(ct);
@@ -66,7 +66,7 @@ public sealed class CompactionStartupHostedService(
             catch (OperationCanceledException) { }
             catch (Exception ex)
             {
-                logger.ZLogError(ex, $"StopAsync");
+                logger.ZLogError(ex, $"Error occurred during hosted service shutdown in StopAsync");
             }
         }
     }

--- a/SendgridParquetViewer/Services/CompactionStartupHostedService.cs
+++ b/SendgridParquetViewer/Services/CompactionStartupHostedService.cs
@@ -5,11 +5,21 @@ namespace SendgridParquetViewer.Services;
 public sealed class CompactionStartupHostedService(
     ILogger<CompactionStartupHostedService> logger,
     CompactionService compactionService
-) : IHostedService, IAsyncDisposable
+) : BackgroundService
 {
     private readonly TimeSpan _periodicSpan = TimeSpan.FromDays(1);
-    private CancellationTokenSource? _cts;
-    private Task? _loopTask;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await Run(stoppingToken);
+        using var timer = new PeriodicTimer(_periodicSpan);
+        while (await timer.WaitForNextTickAsync(stoppingToken))
+        {
+            await Run(stoppingToken);
+        }
+
+        await compactionService.StopCompactionAsync(CancellationToken.None);
+    }
 
     private async Task Run(CancellationToken ct)
     {
@@ -27,59 +37,5 @@ public sealed class CompactionStartupHostedService(
         {
             logger.ZLogError(ex, $"CompactionStartupHostedService");
         }
-    }
-
-    public Task StartAsync(CancellationToken ct)
-    {
-        _cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        _ = Run(_cts.Token).ContinueWith(t =>
-        {
-            if (t.Exception != null)
-            {
-                logger.ZLogError(t.Exception, "Exception in initial compaction Run task");
-            }
-        }, TaskContinuationOptions.OnlyOnFaulted);
-        _loopTask = Task.Run(async () =>
-        {
-            using var timer = new PeriodicTimer(_periodicSpan);
-            while (await timer.WaitForNextTickAsync(_cts.Token))
-            {
-                await Run(_cts.Token);
-            }
-        }, _cts.Token);
-        return Task.CompletedTask;
-    }
-
-    public async Task StopAsync(CancellationToken ct)
-    {
-        if (_cts != null)
-        {
-            await _cts.CancelAsync();
-        }
-        await compactionService.StopCompactionAsync(ct);
-        if (_loopTask != null)
-        {
-            try
-            {
-                await _loopTask;
-            }
-            catch (OperationCanceledException) { }
-            catch (Exception ex)
-            {
-                logger.ZLogError(ex, $"Error occurred during hosted service shutdown in StopAsync");
-            }
-        }
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        if (_cts != null)
-        {
-            await _cts.CancelAsync();
-            _cts.Dispose();
-            _cts = null;
-        }
-        // Dispose is called after StopAsync, so no need to call StopCompactionAsync here.
-        // await compactionService.StopCompactionAsync(CancellationToken.None);
     }
 }

--- a/SendgridParquetViewer/Services/CompactionStartupHostedService.cs
+++ b/SendgridParquetViewer/Services/CompactionStartupHostedService.cs
@@ -18,9 +18,9 @@ public sealed class CompactionStartupHostedService(
             {
                 await Run(stoppingToken);
             }
-        }, stoppingToken).ContinueWith(async _ =>
+        }, stoppingToken).ContinueWith(_ =>
         {
-            await compactionService.StopCompactionAsync(CancellationToken.None);
+            return compactionService.StopCompactionAsync(CancellationToken.None);
         }, CancellationToken.None);
 
     private async Task Run(CancellationToken ct)

--- a/SendgridParquetViewer/Services/CompactionStartupHostedService.cs
+++ b/SendgridParquetViewer/Services/CompactionStartupHostedService.cs
@@ -18,10 +18,7 @@ public sealed class CompactionStartupHostedService(
             {
                 await Run(stoppingToken);
             }
-        }, stoppingToken).ContinueWith(_ =>
-        {
-            return compactionService.StopCompactionAsync(CancellationToken.None);
-        }, CancellationToken.None);
+        }, stoppingToken).ContinueWith(_ => compactionService.StopCompactionAsync(CancellationToken.None), CancellationToken.None);
 
     private async Task Run(CancellationToken ct)
     {
@@ -29,7 +26,7 @@ public sealed class CompactionStartupHostedService(
         try
         {
             var compactionStartResult = await compactionService.StartCompactionAsync(ct);
-            if (compactionStartResult?.StartTask != null)
+            if (compactionStartResult.StartTask != null)
             {
                 await compactionStartResult.StartTask;
             }

--- a/SendgridParquetViewer/Services/CompactionStartupHostedService.cs
+++ b/SendgridParquetViewer/Services/CompactionStartupHostedService.cs
@@ -32,7 +32,13 @@ public sealed class CompactionStartupHostedService(
     public Task StartAsync(CancellationToken ct)
     {
         _cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        _ = Run(_cts.Token);
+        _ = Run(_cts.Token).ContinueWith(t =>
+        {
+            if (t.Exception != null)
+            {
+                logger.ZLogError(t.Exception, "Exception in initial compaction Run task");
+            }
+        }, TaskContinuationOptions.OnlyOnFaulted);
         _loopTask = Task.Run(async () =>
         {
             using var timer = new PeriodicTimer(_periodicSpan);


### PR DESCRIPTION
概要
- コンパクション処理をバックグラウンドで日次実行するよう変更し、アプリ起動をブロックしない構成に改善。
- 実行中の重複起動を抑止し、停止時にはループ完了を待機して安全に終了。
- 運用時の安定性と可観測性を高めるためのリソース解放・ログ整備を実施。

主な変更
- SendgridParquetViewer/Services/CompactionStartupHostedService.cs
  - PeriodicTimer による日次スケジューリングを実装。
  - 初回実行は await せずノンブロッキングで開始（アプリ起動を阻害しない）。
  - 実行本体を Run(ct) に分離。停止時は `_cts.CancelAsync()` → `compactionService.StopCompactionAsync(ct)` → `_loopTask` await で同期的に終了。
  - DisposeAsync で `_cts.CancelAsync()` と `Dispose()` を明示し、リソースリークを防止。
  - 例外は ZLogger で記録し、周期ループは継続。

- SendgridParquetViewer/Services/CompactionService.cs
  - `StartCompactionAsync`: 実行中（`StartTask.IsCompleted != true`）は既存の `CompactionStartResult` を返し、重複起動を抑止。
  - `StopCompactionAsync`: 実行タスクの完了待機後、`_compactionStartResult = null` で状態クリア。
  - 既存のセマフォで Start/Stop の競合を防止。

動作/設計上のポイント
- 起動直後に1回実行を開始し、その後は 24h 間隔で周期実行。
- 停止時のキャンセルがバックグラウンドループと実行中コンパクションへ確実に伝播。
- Faulted/Cancelled を含む「未完了」実行がある場合は再入しない（完了後は次サイクルで再開）。

テスト観点
- 起動がブロックされない（初回コンパクション中でもアプリは応答）。
- 周期が概ね 24h でトリガーされる（処理時間と無関係に周期駆動）。
- `StopAsync` 呼び出しでコンパクションとループが速やかに停止し、完了待機が行われる。
- `StartCompactionAsync` 多重呼び出し時に重複起動せず同一結果を返す。
- コンパクション失敗時でも次サイクルで再試行される。

既知の留意点 / フォローアップ
- `Run` 内の例外ログは運用方針に応じてレベル調整（OperationCanceledException は情報/無視、その他は Warning/Error）を検討。
- 周期ループの開始/終了を Info ログで補足すると可観測性が向上。
- `_loopTask` await 時の一般例外（Faulted）も Warning ログで記録する運用を検討。

影響範囲
- Viewer のホスティング/バックグラウンド実行まわりのみ。外部公開 API やデータ形式の破壊的変更はなし。

関連ファイル
- SendgridParquetViewer/Services/CompactionStartupHostedService.cs
- SendgridParquetViewer/Services/CompactionService.cs

レビュー依頼
- 周期実行のポリシー（初回ノンブロッキング / 24h 周期）と、重複起動ガードの方針が要件に合致しているか確認をお願いします。
- 例外時のログレベルとメッセージ方針についてもご意見いただけると助かります。
