### PR TITLE
showversion

### DIFF
--- a/SendgridParquetLogger/Helper/CreateBucketService.cs
+++ b/SendgridParquetLogger/Helper/CreateBucketService.cs
@@ -1,0 +1,9 @@
+﻿using SendgridParquet.Shared;
+
+namespace SendgridParquetLogger.Helper;
+
+internal class CreateBucketService(S3StorageService s3StorageService) : BackgroundService
+{
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+        => Task.Run(() => s3StorageService.CreateBucketIfNotExistsAsync(stoppingToken), stoppingToken);
+}

--- a/SendgridParquetLogger/Program.cs
+++ b/SendgridParquetLogger/Program.cs
@@ -57,15 +57,11 @@ builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddSingleton<ParquetService>(); // 無状態のため AddSingleton
 builder.Services.AddSingleton<RequestValidator>(); // 処理は無状態 PublicKey の生成をキャッシュするため AddSingleton
 builder.Services.AddHttpClient<S3StorageService>();
+builder.Services.AddHostedService<CreateBucketService>();
 builder.Services.AddScoped<WebhookHelper>();
 
 var app = builder.Build();
 
-// if (!app.Environment.IsDevelopment())
-{
-    var s3Service = app.Services.GetRequiredService<S3StorageService>();
-    await s3Service.CreateBucketIfNotExistsAsync(CancellationToken.None);
-}
 #if UseSwagger
 {
     //app.UseSwagger(); // dotnet 8.0 以前用

--- a/SendgridParquetLogger/Program.cs
+++ b/SendgridParquetLogger/Program.cs
@@ -83,8 +83,9 @@ app.MapControllers();
 // Minimal APIs when UseSwagger is not defined
 app.MapGet("/health6QQl", (TimeProvider timeProvider) =>
 {
+    var version = $"{typeof(Program).Assembly.GetName().Version?.ToString()}";
     var ts = timeProvider.GetUtcNow();
-    string json = $"{{\"status\":\"healthy\",\"timestamp\":\"{ts:O}\"}}";
+    string json = $"{{\"status\":\"healthy\",\"timestamp\":\"{ts:O}\",\"version\":\"{version}\"}}";
     return Results.Text(json, "application/json");
 });
 

--- a/SendgridParquetLogger/Properties/launchSettings.json
+++ b/SendgridParquetLogger/Properties/launchSettings.json
@@ -26,7 +26,7 @@
       "launchUrl": "swagger",
       "applicationUrl": "https://localhost:7277;http://localhost:5206",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "ASPNETCORE_ENVIRONMENT"
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
     "IIS Express": {


### PR DESCRIPTION
## 概要
- S3 バケット作成処理をホストされた `CreateBucketService` へ移行し、起動時のアドホック呼び出しを排除
- `/health6QQl` の応答にアセンブリのバージョンを付与し、運用時の診断性を向上
- `launchSettings.json` のローカル実行プロファイルを `Development` に統一

## 変更内容
- SendgridParquetLogger/Helper/CreateBucketService.cs: バックグラウンドサービスで `CreateBucketIfNotExistsAsync` を実行
- SendgridParquetLogger/Program.cs:
  - `AddHostedService<CreateBucketService>()` を登録
  - ヘルスチェック JSON に `version` フィールドを追加
  - 旧来の明示的な起動時バケット作成ロジックを削除
- SendgridParquetLogger/Properties/launchSettings.json:
  - `ASPNETCORE_ENVIRONMENT` を `Development` に設定

## 目的・背景
- バケット作成を依存性注入のライフサイクルに沿った初期化へ整理し、起動経路の簡素化と可観測性の向上を図る
- 稼働中バージョンを `/health6QQl` で確認可能にし、デプロイ検証やトラブルシュートを容易にする
- ローカル動作の前提を明示し、開発体験のばらつきを低減

## 動作確認
- API 起動後、MinIO/S3 側に対象バケットが自動作成されること
- `GET /health6QQl` が以下の形式でレスポンスを返すこと（例）:
  - `{"status":"healthy","timestamp":"<ISO8601>","version":"<SemVer>"}`
- 既存の Webhook 処理にリグレッションがないこと

## 互換性/影響範囲
- バケット作成の呼び出しタイミングがホスト初期化時（バックグラウンド）へ移行（機能的な変更はなし）
- 本番環境での挙動差はありません（`CreateBucketIfNotExistsAsync` の再実行は冪等）

## リスクと緩和策
- バケット作成が失敗した場合に備え、アプリログで失敗を検出可能
- 既存の S3 設定（環境変数/Options）がある前提。設定不備時は従来同様に失敗ログで検知

## チェックリスト
- [ ] 主要シナリオの手動確認（ヘルスエンドポイント、S3 バケット作成）
- [ ] CI ビルド通過
- [ ] 必要に応じてリリースノートへ記載（ヘルス応答フォーマットの拡張）
