### PR TITLE
feat(viewer): About ページに GCMemoryInfo と一時フォルダ情報を追加

### DIFF
--- a/SendgridParquetViewer/Components/Pages/About.razor
+++ b/SendgridParquetViewer/Components/Pages/About.razor
@@ -262,7 +262,7 @@
             FragmentedBytes: FormatBytes(gcInfo.FragmentedBytes),
             TotalCommittedBytes: FormatBytes(gcInfo.TotalCommittedBytes),
             PromotedBytes: FormatBytes(gcInfo.PromotedBytes),
-            PinnedObjectsCount: FormatBytes(gcInfo.PinnedObjectsCount)
+            PinnedObjectsCount: gcInfo.PinnedObjectsCount.ToString()
             );
         }
     }


### PR DESCRIPTION
概要
- コンテナ/本番環境でのメモリ状況と一時領域の可視化を追加し、障害時の診断容易性を向上
- 環境変数一覧をマスク付きで表示し、セキュリティに配慮しつつ状況確認を可能に

変更点
- GCMemoryInfo を表示
  - HighMemoryLoadThresholdBytes / MemoryLoadBytes / TotalAvailableMemoryBytes
  - HeapSizeBytes / FragmentedBytes / TotalCommittedBytes
  - PromotedBytes / PinnedObjectsCount
- 一時フォルダ情報を表示
  - Path.GetTempPath()、合計容量、空き容量、ドライブ種別、ファイルシステム
  - 取得失敗時は警告表示＋ZLoggerで警告ログ
- 環境変数一覧を表示（機微情報はマスク）
  - マスク対象: key / secret / password / token / connectionstring を含む名前
- 対象ファイル: SendgridParquetViewer/Components/Pages/About.razor のみ

動作確認
- SendgridParquetViewer を起動し /about にアクセス
- 値が表示されること
- マスク対象の環境変数が **** で表示されること
- ドライブ情報取得失敗時、警告メッセージが表示されログに警告が出力されること

影響範囲
- Viewer の About ページのUI追加のみ。既存API/処理への影響なし

セキュリティ
- 機微値は画面表示でマスク（保存・送信なし）

備考
- ブランチ: features/dockerGcMemory → main へのマージ
- 変更は immutable な record/配列中心（IEnumerable での逐次化利用）
