### PR TITLE
Compaction のストリーミング化

### DIFF
--- a/SendgridParquetLog.AppHost/Program.cs
+++ b/SendgridParquetLog.AppHost/Program.cs
@@ -24,7 +24,7 @@ void AddSolutionApps(Func<string> serviceUrlFactory, string region, string acces
         .WithEnvironment("S3__ACCESSKEY", accessKey)
         .WithEnvironment("S3__SECRETKEY", secretKey)
         .WithEnvironment("S3__BUCKETNAME", bucketName)
-        .WithEnvironment("AzureAd__Instance", "");
+        .WithEnvironment("ENABLE_DEV_AUTH", "true");
 }
 
 var s3Section = builder.Configuration.GetSection("S3");

--- a/SendgridParquetViewer/Models/CompactionBatchContext.cs
+++ b/SendgridParquetViewer/Models/CompactionBatchContext.cs
@@ -26,7 +26,7 @@ internal class CompactionBatchContext(RunStatusContext runStatusContext, DateOnl
     /// </summary>
     internal long ProcessedBytes => _processedBytes;
 
-    public void AddProcessedFile(string parquetFile, int parquetDataLength, DateTimeOffset now)
+    public void AddProcessedFile(string parquetFile, long parquetDataLength, DateTimeOffset now)
     {
         _processingFiles.Enqueue(parquetFile);
         Interlocked.Add(ref _processedBytes, parquetDataLength);

--- a/SendgridParquetViewer/Models/CompactionOptions.cs
+++ b/SendgridParquetViewer/Models/CompactionOptions.cs
@@ -10,11 +10,6 @@ public class CompactionOptions
     public long MaxBatchSizeBytes { get; set; } = 512 * 1024 * 1024;
 
     /// <summary>
-    /// メモリ上で保持する最大イベント数
-    /// </summary>
-    public int MaxEventsPerChunk { get; set; } = 10_000;
-
-    /// <summary>
     /// 標準では JST基準で昨日以前のものが対象になる
     /// </summary>
     public TimeSpan TargetBefore { get; set; } = TimeSpan.FromDays(-1);

--- a/SendgridParquetViewer/Models/CompactionOptions.cs
+++ b/SendgridParquetViewer/Models/CompactionOptions.cs
@@ -10,6 +10,11 @@ public class CompactionOptions
     public long MaxBatchSizeBytes { get; set; } = 512 * 1024 * 1024;
 
     /// <summary>
+    /// メモリ上で保持する最大イベント数
+    /// </summary>
+    public int MaxEventsPerChunk { get; set; } = 10_000;
+
+    /// <summary>
     /// 標準では JST基準で昨日以前のものが対象になる
     /// </summary>
     public TimeSpan TargetBefore { get; set; } = TimeSpan.FromDays(-1);

--- a/SendgridParquetViewer/Properties/launchSettings.json
+++ b/SendgridParquetViewer/Properties/launchSettings.json
@@ -7,6 +7,7 @@
         "launchBrowser": true,
         "applicationUrl": "http://localhost:5007",
         "environmentVariables": {
+          "ENABLE_DEV_AUTH": "true",
           "ASPNETCORE_ENVIRONMENT": "Development"
         }
       },
@@ -16,6 +17,7 @@
         "launchBrowser": true,
         "applicationUrl": "https://localhost:7100;http://localhost:5007",
         "environmentVariables": {
+          "ENABLE_DEV_AUTH": "true",
           "ASPNETCORE_ENVIRONMENT": "Development"
         }
       }

--- a/SendgridParquetViewer/Services/CompactionService.cs
+++ b/SendgridParquetViewer/Services/CompactionService.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Concurrent;
+﻿using System.Buffers;
+using System.Collections.Concurrent;
+using System.Globalization;
 using System.Text.Json;
 using System.Threading.Channels;
 
@@ -540,8 +542,9 @@ public class CompactionService(
     /// </summary>
     class SendGridEventsOneFile
     {
-        internal IReadOnlyCollection<SendGridEvent> SendGridEvents { get; init; } = [];
+        internal IReadOnlyList<SendGridEvent> SendGridEvents { get; init; } = Array.Empty<SendGridEvent>();
         internal string ParquetFile { get; init; } = string.Empty;
+        internal int ChunkIndex { get; init; }
     }
 
     class FetchReadParquetFilesResult
@@ -606,8 +609,13 @@ public class CompactionService(
                 {
                     Directory.CreateDirectory(targetFolder);
                 }
-                string originalFileName = Path.GetFileName(sendgridEventOneFile.ParquetFile);
-                string targetFilePath = Path.Combine(targetFolder, originalFileName);
+                string originalFileNameWithoutExtension = Path.GetFileNameWithoutExtension(sendgridEventOneFile.ParquetFile);
+                string extension = Path.GetExtension(sendgridEventOneFile.ParquetFile);
+                string chunkSuffix = sendgridEventOneFile.ChunkIndex == 0
+                    ? string.Empty
+                    : $"_{sendgridEventOneFile.ChunkIndex.ToString("D4", CultureInfo.InvariantCulture)}";
+                string targetFileName = string.Concat(originalFileNameWithoutExtension, chunkSuffix, extension);
+                string targetFilePath = Path.Combine(targetFolder, targetFileName);
                 await using var fs = new FileStream(targetFilePath, FileMode.Create, FileAccess.Write, FileShare.None, DisposableTempFile.BufferSize, useAsync: true);
                 await MemoryPackSerializer.SerializeAsync(fs, eventsByHour, cancellationToken: token);
 
@@ -625,45 +633,92 @@ public class CompactionService(
         foreach (string parquetFile in ctx.CandidateParquetFiles)
         {
             token.ThrowIfCancellationRequested();
+
+            if (ctx.ProcessedBytes >= _compactionOptions.MaxBatchSizeBytes && ctx.ProcessedBytes > 0)
+            {
+                logger.ZLogInformation($"Reached read limit {_compactionOptions.MaxBatchSizeBytes}, stopping further reads in this batch");
+                break;
+            }
+
             try
             {
-                var sendGridEvents = new ConcurrentQueue<SendGridEvent>();
                 logger.ZLogInformation($"Reading Parquet file: {parquetFile}");
-                byte[] parquetData = await s3StorageService.GetObjectAsByteArrayAsync(parquetFile, token);
-                if (ctx.ProcessedBytes + parquetData.Length > _compactionOptions.MaxBatchSizeBytes)
+
+                using HttpResponseMessage response = await s3StorageService.GetObjectAsync(parquetFile, token);
+                if (!response.IsSuccessStatusCode)
+                {
+                    logger.ZLogWarning($"Failed to download parquet file: {parquetFile} HttpStatus:{response.StatusCode}");
+                    ctx.AddFailedReadingParquetFiles(parquetFile, timeProvider.GetUtcNow());
+                    continue;
+                }
+
+                long? responseLength = response.Content.Headers.ContentLength;
+                if (ctx.ProcessedBytes > 0
+                    && responseLength.HasValue
+                    && ctx.ProcessedBytes + responseLength.Value > _compactionOptions.MaxBatchSizeBytes)
                 {
                     logger.ZLogInformation(
                         $"Reached read limit {_compactionOptions.MaxBatchSizeBytes}, stopping further reads in this batch");
                     break;
                 }
 
-                if (parquetData.Any())
+                await using FileStream parquetTempStream = DisposableTempFile.Open(nameof(FetchParquetFilesProducerAsync));
+                await using Stream responseStream = await response.Content.ReadAsStreamAsync(token);
+                await responseStream.CopyToAsync(parquetTempStream, DisposableTempFile.BufferSize, token);
+                parquetTempStream.Seek(0, SeekOrigin.Begin);
+
+                long processedBytes = parquetTempStream.Length;
+                using ParquetReader parquetReader = await ParquetReader.CreateAsync(parquetTempStream, cancellationToken: token);
+
+                int maxEventsPerChunk = Math.Max(1, _compactionOptions.MaxEventsPerChunk);
+                var chunkBuffer = new ArrayBufferWriter<SendGridEvent>(maxEventsPerChunk);
+                int chunkIndex = 0;
+                long eventsRead = 0;
+
+                async ValueTask FlushChunkAsync()
                 {
-                    await using var ms = new MemoryStream(parquetData);
-                    using ParquetReader parquetReader = await ParquetReader.CreateAsync(ms, cancellationToken: token);
-                    for (int rowGroupIndex = 0; rowGroupIndex < parquetReader.RowGroupCount; rowGroupIndex++)
+                    if (chunkBuffer.WrittenCount == 0)
                     {
-                        using ParquetRowGroupReader rowGroupReader = parquetReader.OpenRowGroupReader(rowGroupIndex);
-                        await foreach (SendGridEvent sendGridEvent in parquetService.ReadRowGroupEventsAsync(
-                                           rowGroupReader, parquetReader, token))
-                        {
-                            sendGridEvents.Enqueue(sendGridEvent);
-                        }
+                        return;
                     }
+
+                    SendGridEvent[] chunkEvents = chunkBuffer.WrittenSpan.ToArray();
+                    chunkBuffer.Clear();
+                    int currentChunkIndex = chunkIndex;
+                    chunkIndex += 1;
 
                     await writer.WriteAsync(
                         new SendGridEventsOneFile
                         {
                             ParquetFile = parquetFile,
-                            SendGridEvents = sendGridEvents.ToArray(),
+                            SendGridEvents = chunkEvents,
+                            ChunkIndex = currentChunkIndex,
                         }, token);
-                    ctx.AddProcessedFile(parquetFile, parquetData.Length, timeProvider.GetUtcNow());
-                    logger.ZLogInformation($"Successfully read {sendGridEvents.Count} events from {parquetFile}");
                 }
-                else
+
+                for (int rowGroupIndex = 0; rowGroupIndex < parquetReader.RowGroupCount; rowGroupIndex++)
                 {
-                    logger.ZLogWarning($"Empty parquet file: {parquetFile}");
+                    token.ThrowIfCancellationRequested();
+                    using ParquetRowGroupReader rowGroupReader = parquetReader.OpenRowGroupReader(rowGroupIndex);
+                    await foreach (SendGridEvent sendGridEvent in parquetService.ReadRowGroupEventsAsync(rowGroupReader, parquetReader, token))
+                    {
+                        token.ThrowIfCancellationRequested();
+                        Span<SendGridEvent> span = chunkBuffer.GetSpan(1);
+                        span[0] = sendGridEvent;
+                        chunkBuffer.Advance(1);
+                        eventsRead += 1;
+
+                        if (chunkBuffer.WrittenCount >= maxEventsPerChunk)
+                        {
+                            await FlushChunkAsync();
+                        }
+                    }
                 }
+
+                await FlushChunkAsync();
+
+                ctx.AddProcessedFile(parquetFile, processedBytes, timeProvider.GetUtcNow());
+                logger.ZLogInformation($"Successfully read {eventsRead} events in {chunkIndex} chunks from {parquetFile}");
             }
             catch (OperationCanceledException)
             {

--- a/codinglog/Gpt202509281709.md
+++ b/codinglog/Gpt202509281709.md
@@ -1,0 +1,11 @@
+# プロンプト
+- SendgridParquetViewer/Services/CompactionService.cs のコンパクション処理で 1GB メモリ制限を超えて Docker インスタンスが再起動するため、対応すること
+- AGENTS.md 記載の開発ルール（非 sudo、IReadOnlyList<T> の利用推奨、dotnet format 実行など）
+
+# 処理内容
+- CompactionService を解析し、高メモリ使用箇所（S3 からの全量読み込みと大量イベント保持）を特定
+- S3 読み込みをストリーミング化し、一時ファイル経由で ParquetReader を開くようリファクタリング
+- イベントをチャンク化してチャネルへ送信するよう変更し、chunk index やオプション `MaxEventsPerChunk` を追加
+- Chunk index に基づき一時 MemoryPack ファイル名を一意化するよう消费者処理を更新
+- CompactionBatchContext のバイト数トラッキングを long 対応に変更
+- dotnet build でコンパイル確認（サンドボックス拒否のため権限昇格して再実行）


### PR DESCRIPTION
概要
- 目的: コンパクション処理の高メモリ使用を解消し安定化。開発検証を容易にするため認証トグルを追加。
- 要点: Compaction をストリーミング実装へ刷新（時間帯分割＋逐次 Parquet 化）。ENABLE_DEV_AUTH を導入。Viewer の起動連携/表示強化。

主な変更点
- Compaction（メモリ抑制・ストリーミング化）
  - S3 の日別 Parquet を読み込み、イベントを1時間ごとにパックして逐次 Parquet 生成。
  - Bounded Channel（先読み2）＋ MaxBatchSizeBytes で一度に扱うデータ量を制御。
  - Parquet 変換は ConvertToParquetStreamingAsync、RowGroupSize=200,000（約24MiB/200k行）を採用。
  - 出力 Verify 成功時のみ元ファイル削除。失敗時は出力側破棄で安全性確保。
  - 停滞検知で run.json を終端化し lock を解放。
  - 関連: SendgridParquetViewer/Services/CompactionService.cs
- 起動連携/表示
  - HostedService で起動時にコンパクション開始。
  - 進捗/ステータス（RunStatusSubject）を UI に反映。
  - 関連: SendgridParquetViewer/Services/CompactionStartupHostedService.cs, SendgridParquetViewer/Components/Pages/Compaction.razor
- 開発用認証トグル
  - ENABLE_DEV_AUTH=true で開発用認証/認可を有効化。本番は Azure AD（AppRoles）を維持。
  - 関連: SendgridParquetViewer/Program.cs, docker-compose.yml, SendgridParquetLog.AppHost/Program.cs

互換性/移行
- Parquet スキーマ互換は維持。出力は v3compaction/YYYY/MM/DD/HH/ に集約。
- v3raw はソースアーカイブとして保持。Verify 成功後に元ファイルを安全に削除。
- 対象日は「UTC の前日まで」。

リスクと緩和
- ファイル分割増: Verify と命名規則で重複/不整合を回避。
- 大量データ: MaxBatchSizeBytes によりバッチ境界を強制、必要に応じて調整。
- ロック: S3 ロックで単一実行を保証。停滞検知で強制終端・解放。
- ストレージコスト: Raw と Compaction 併存期間は監視のうえ閾値調整。

変更ファイル（抜粋）
- SendgridParquetViewer/Services/CompactionService.cs
- SendgridParquetViewer/Models/CompactionBatchContext.cs
- SendgridParquetViewer/Properties/launchSettings.json

チェックリスト
- [ ] Start/Stop/再開が期待通りに動作
- [ ] run.json/run.lock と UI 表示の一致
- [ ] 出力 Parquet 検証後に Raw を削除している
- [ ] ENABLE_DEV_AUTH=false で Azure AD 認証が既存通り
- [ ] Aspire / Docker Compose の両方で起動・確認

備考/フォローアップ
- RowGroupSize/MaxInactivityDuration/チャネル容量のオプション化を検討。
- Producer の全件バッファを段階的に削減（逐次 hour 分割）する改修を別 PR で予定。
