### PR TITLE
`StartCompactionAsyncInLock` にロック状態チェックを統合

### DIFF
--- a/SendgridParquetViewer/Components/Pages/Compaction.razor
+++ b/SendgridParquetViewer/Components/Pages/Compaction.razor
@@ -26,20 +26,6 @@
                     <FluentLabel Typo="Typography.Subject">Current Status</FluentLabel>
                 </FluentHeader>
                 
-                @if (_isWaitingForLock)
-                {
-                    <FluentProgressRing />
-                    <p>他インスタンスのロックの有効期限切れを待機しています...
-                        @if (_lockExpiresAt.HasValue)
-                        {
-                            <br /><small>Lock ExpiresAt: @_lockExpiresAt.Value.ToString("s")</small>
-                        }
-                        @if (_runStatus != null)
-                        {
-                            <br /><small>Note: The status information below may be stale while waiting for the lock.</small>
-                        }
-                    </p>
-                }
                 @if (_runStatus != null)
                 {
                     <p>
@@ -155,7 +141,7 @@
                 <FluentButton Appearance="Appearance.Accent"
                              OnClick="StartCompaction"
                              Loading="_isStarting"
-                             Disabled="@(_runStatus?.EndTime == null && _runStatus != null)">
+                             Disabled="@(IsStartDisabled)">
                     Start Compaction
                 </FluentButton>
 
@@ -191,13 +177,10 @@
 </FluentCard>
 
 @code {
-	private static readonly TimeSpan LockExpiryClockSkewMargin = TimeSpan.FromSeconds(60);
 	private RunStatus? _runStatus;
 	private LockInfo? _lockInfo;
 	private bool _isLoadingStatus;
 	private bool _isStarting;
-	private bool _isWaitingForLock;
-	private DateTimeOffset? _lockExpiresAt;
 	private string _message = string.Empty;
 	private IDisposable? _runStatusSubjectSubscription;
 	private PeriodicTimer? _lockCountdownTimer;
@@ -217,6 +200,10 @@
 		return $"{remaining.Seconds}秒";
 	}
 
+	bool IsStartDisabled =>
+		CompactionService.IsCompactionRunningLocally
+		|| (_lockInfo != null && _lockInfo.ExpiresAt > TimeProvider.GetUtcNow());
+
 	protected override async Task OnInitializedAsync()
 	{
 		try
@@ -229,12 +216,6 @@
 			ShowMessage("ステータスの取得に失敗しました。ロック状態を確認しています。", MessageIntent.Error);
 		}
 
-		// 自プロセスでスレッド進行中でなく、run.json が Running 状態の場合はロックの期限切れを確認する
-		if (_runStatus != null && !_runStatus.EndTime.HasValue && !CompactionService.IsCompactionRunningLocally)
-		{
-			await WaitForAndCleanupStalledLockAsync();
-		}
-
 		_runStatusSubjectSubscription = CompactionService.RunStatusSubject
 			.ObserveOnCurrentSynchronizationContext()
             .Subscribe(runStatus =>
@@ -243,77 +224,6 @@
                 _runStatus = runStatus;
                 StateHasChanged();
 			});
-	}
-
-	private async Task WaitForAndCleanupStalledLockAsync()
-	{
-		_isWaitingForLock = true;
-		StateHasChanged();
-		try
-		{
-			var lockInfo = await CompactionService.CleanupExpiredLockAsync(_cts.Token);
-			if (lockInfo != null)
-			{
-				// ロックが有効期限内 → ExpiresAt まで待機
-				// 他インスタンスとの時計のずれを考慮し余裕を持たせる
-				var waitTime = lockInfo.ExpiresAt - TimeProvider.GetUtcNow() + LockExpiryClockSkewMargin;
-				if (waitTime > TimeSpan.Zero)
-				{
-					_lockExpiresAt = lockInfo.ExpiresAt;
-					StateHasChanged();
-					// 管理画面のため同時ユーザー数は限定的であり、最大30分の待機中も SignalR 接続を維持する
-					await Task.Delay(waitTime, _cts.Token);
-				}
-				else
-				{
-					// 時計のずれなどにより待機時間が 0 以下となった場合はログに記録して即時クリーンアップを試行する
-					Logger.LogWarning(
-						"Calculated wait time for lock cleanup is non-positive. WaitTime={WaitTime}, ExpiresAt={ExpiresAt}, Now={Now}",
-						waitTime,
-						lockInfo.ExpiresAt,
-						TimeProvider.GetUtcNow());
-				}
-
-				// 待機後に再度クリーンアップ
-				var secondLockInfo = await CompactionService.CleanupExpiredLockAsync(_cts.Token);
-				if (secondLockInfo != null)
-				{
-					// 2回目に取得したロック情報が同じロックか、新しいロックかを判定する
-					if (secondLockInfo.LockId == lockInfo.LockId)
-					{
-						// 同じロックが残っている → クリーンアップ失敗として扱う
-						Logger.LogWarning("Lock cleanup after wait did not remove original lock. Lock info: {@LockInfo}", secondLockInfo);
-						ShowMessage("ロックのクリーンアップに失敗しました。", MessageIntent.Error);
-					}
-					else
-					{
-						// 別のインスタンスが新しいロックを取得した可能性がある
-						Logger.LogInformation(
-							"A new lock was acquired after waiting for the previous lock to expire. Previous: {@PreviousLock}, New: {@NewLock}",
-							lockInfo,
-							secondLockInfo);
-						ShowMessage("別のプロセスによって新しいロックが取得されました。しばらくしてから再試行してください。", MessageIntent.Warning);
-					}
-				}
-			}
-
-			await RefreshStatus();
-		}
-		catch (OperationCanceledException)
-		{
-			// ページ離脱時のキャンセル
-		}
-		catch (Exception ex)
-		{
-			Logger.LogError(ex, "Error during stalled lock cleanup");
-			ShowMessage("ロックのクリーンアップに失敗しました。", MessageIntent.Error);
-		}
-		finally
-		{
-			_isWaitingForLock = false;
-			_lockExpiresAt = null;
-			StateHasChanged();
-		}
 	}
 
 	private async Task RefreshStatus()

--- a/SendgridParquetViewer/Services/CompactionService.cs
+++ b/SendgridParquetViewer/Services/CompactionService.cs
@@ -43,70 +43,6 @@ public class CompactionService(
     public bool IsCompactionRunningLocally =>
         _compactionStartResult?.StartTask is { IsCompleted: false };
 
-    /// <summary>
-    /// 期限切れのロックをクリーンアップする。
-    /// ロックが有効期限内の場合は LockInfo を返す（呼び出し元が ExpiresAt まで待機に使う）。
-    /// ロックが存在しない、ローカルで実行中、または期限切れで処理完了した場合は null を返す。
-    /// </summary>
-    public async Task<LockInfo?> CleanupExpiredLockAsync(CancellationToken ct)
-    {
-        if (IsCompactionRunningLocally) return null;
-
-        var lockInfo = await s3LockService.GetLockInfoAsync(ct);
-        if (lockInfo == null) return null;
-
-        var now = timeProvider.GetUtcNow();
-        if (lockInfo.ExpiresAt > now)
-        {
-            return lockInfo; // まだ有効期限内 → 呼び出し元が待つ
-        }
-
-        // 期限切れ → run.json を異常終了マーク + ロック削除
-        logger.ZLogWarning($"Expired lock detected (ExpiresAt: {lockInfo.ExpiresAt:s}, Owner: {lockInfo.OwnerId}). Cleaning up.");
-
-        var (runJsonPath, _) = SendGridPathUtility.GetS3CompactionRunFile();
-        var result = await s3StorageService.GetObjectWithETagAsync(runJsonPath, ct);
-        RunStatus? runStatus = result.Content.Length > 0
-            ? JsonSerializer.Deserialize(result.Content, AppJsonSerializerContext.Default.RunStatus)
-            : null;
-
-        if (runStatus is { EndTime: null })
-        {
-            runStatus.EndTime = now;
-            runStatus.LastUpdated = now;
-            runStatus.AbnormalTermination = true;
-
-            try
-            {
-                byte[] updatedRunJson = JsonSerializer.SerializeToUtf8Bytes(runStatus, AppJsonSerializerContext.Default.RunStatus);
-                bool written = await s3StorageService.PutObjectWithConditionAsync(runJsonPath, updatedRunJson, result.ETag, ct);
-                if (!written)
-                {
-                    logger.ZLogInformation($"run.json was already updated by another instance. Proceeding to lock deletion.");
-                }
-                else
-                {
-                    logger.ZLogWarning($"Marked stalled run as abnormally terminated (started {runStatus.StartTime:s})");
-                }
-            }
-            catch (Exception ex)
-            {
-                logger.ZLogError(ex, $"Failed to persist abnormal termination status. Skipping lock deletion to retry on next cleanup.");
-                return null; // run.json が更新できなければロック削除をスキップし次回再試行
-            }
-
-            RunStatusSubject.OnNext(runStatus);
-        }
-
-        bool invalidated = await s3LockService.TryInvalidateExpiredLockAsync(lockInfo, ct);
-        if (!invalidated)
-        {
-            logger.ZLogInformation($"Skip invalidating expired lock because lock state changed concurrently.");
-        }
-
-        return null;
-    }
-
     public Task<LockInfo?> GetLockInfoAsync(CancellationToken ct = default) =>
         s3LockService.GetLockInfoAsync(ct);
 
@@ -188,11 +124,21 @@ public class CompactionService(
             }
             else
             {
-                RunStatusSubject.OnNext(currentStatus);
-                return new CompactionStartResult
+                // 無活動期間が閾値以内でも、ロックが期限切れまたは存在しない場合はストール済みとみなす
+                var lockInfo = await s3LockService.GetLockInfoAsync(ct);
+                if (lockInfo == null || lockInfo.ExpiresAt <= nowUTC)
                 {
-                    Reason = $"Compaction is already running (started {currentStatus.StartTime:s}, last update {lastActivity:s})"
-                };
+                    currentStatus = await FinalizeStalledRunAsync(currentStatus, nowUTC);
+                    logger.ZLogInformation($"FinalizeStalledRunAsync (expired lock) LastUpdated:{currentStatus.LastUpdated}");
+                }
+                else
+                {
+                    RunStatusSubject.OnNext(currentStatus);
+                    return new CompactionStartResult
+                    {
+                        Reason = $"Compaction is already running (started {currentStatus.StartTime:s}, last update {lastActivity:s})"
+                    };
+                }
             }
         }
 

--- a/SendgridParquetViewer/Services/S3LockService.cs
+++ b/SendgridParquetViewer/Services/S3LockService.cs
@@ -10,6 +10,7 @@ namespace SendgridParquetViewer.Services;
 
 public interface IS3LockService
 {
+    TimeSpan LockDuration { get; }
     Task<bool> TryAcquireLockAsync(string lockId, CancellationToken ct);
     Task ExtendLockExpirationAsync(string lockId, CancellationToken ct);
     Task ReleaseLockAsync(string lockId, CancellationToken ct);
@@ -23,7 +24,7 @@ public class S3LockService(
     TimeProvider timeProvider,
     S3StorageService s3StorageService) : IS3LockService
 {
-    private static readonly TimeSpan LockDuration = TimeSpan.FromMinutes(30);
+    public TimeSpan LockDuration { get; } = TimeSpan.FromMinutes(30);
     private static readonly string InstanceId = $"{Environment.MachineName}_{Guid.NewGuid():N}";
 
     private static bool IsSameLock(LockInfo a, LockInfo b) =>


### PR DESCRIPTION
## Summary
- `StartCompactionAsyncInLock` にロック状態チェックを統合し、`EndTime==null` かつロック期限切れの場合に即座にストール判定を行うよう変更
- `CleanupExpiredLockAsync` メソッドを削除（`StartCompactionAsyncInLock` 内で同等のチェックが行われるため不要に）
- `CompactionStartupHostedService` を簡素化し、初回・定時実行の両方で jitter を適用
- `Compaction.razor` からロック待機 UI と `WaitForAndCleanupStalledLockAsync` を削除し、Start ボタンの制御を `IsStartDisabled` プロパティに統一
- `IS3LockService` に `LockDuration` プロパティを追加（既存ビルドエラーの修正）

## Background
`CleanupExpiredLockAsync` は起動時のみ呼ばれ、定時実行パスでは呼ばれないため、起動後にクラッシュが発生した場合にロック期限切れ（≈30分）から最大24時間 Compaction が再開できないギャップがあった。

ロック状態チェックを `StartCompactionAsyncInLock` に統合することで、起動時・定時実行・手動実行のすべてのパスでロック期限切れを検出可能にし、検出速度を最大24時間→約30分に短縮した。

## Test plan
- [ ] `dotnet build` 成功を確認（警告1件は既存の CS9124）
- [ ] `dotnet test` 全テスト通過を確認
- [ ] run.json が `EndTime==null`、ロック期限切れ → Compaction が開始されること
- [ ] run.json が `EndTime==null`、ロック有効 → "already running" が返ること
- [ ] run.json が `EndTime==null`、ロックなし → Compaction が開始されること
- [ ] run.json が `EndTime!=null` → 通常通りロック取得→開始
