### PR TITLE
SendgridParquetViewer に Webhook 受信エンドポイントを追加

### DIFF
--- a/SendgridParquet.Shared/CreateBucketService.cs
+++ b/SendgridParquet.Shared/CreateBucketService.cs
@@ -1,10 +1,13 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
 
-using SendgridParquet.Shared;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
-namespace SendgridParquetLogger.Helper;
+namespace SendgridParquet.Shared;
 
-internal class CreateBucketService : BackgroundService
+public class CreateBucketService : BackgroundService
 {
     private readonly S3StorageService _s3StorageService;
     private readonly ILogger<CreateBucketService> _logger;

--- a/SendgridParquet.Shared/RequestValidator.cs
+++ b/SendgridParquet.Shared/RequestValidator.cs
@@ -1,14 +1,16 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Globalization;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-
-using SendgridParquet.Shared;
 
 using ZLogger;
 
-namespace SendgridParquetLogger.Helper;
+namespace SendgridParquet.Shared;
 
 /// <summary>
 /// This class allows you to use the Event Webhook feature. Read the docs for

--- a/SendgridParquet.Shared/SendGridEventJsonContext.cs
+++ b/SendgridParquet.Shared/SendGridEventJsonContext.cs
@@ -1,0 +1,7 @@
+﻿using System.Text.Json.Serialization;
+
+namespace SendgridParquet.Shared;
+
+[JsonSerializable(typeof(SendGridEvent[]))]
+[JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Default, PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+public partial class SendGridEventJsonContext : JsonSerializerContext;

--- a/SendgridParquet.Shared/SendgridParquet.Shared.csproj
+++ b/SendgridParquet.Shared/SendgridParquet.Shared.csproj
@@ -11,6 +11,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.1" />
     <PackageReference Include="Parquet.Net" Version="5.4.0" />

--- a/SendgridParquet.Shared/WebhookHelper.cs
+++ b/SendgridParquet.Shared/WebhookHelper.cs
@@ -1,17 +1,21 @@
-﻿using System.Buffers;
+﻿using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO;
 using System.IO.Pipelines;
+using System.Linq;
 using System.Net;
 using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-
-using SendgridParquet.Shared;
-
-using SendgridParquetLogger.Models;
 
 using ZLogger;
 
-namespace SendgridParquetLogger.Helper;
+namespace SendgridParquet.Shared;
 
 public class WebhookHelper(
     ILogger<WebhookHelper> logger,
@@ -46,7 +50,7 @@ public class WebhookHelper(
                 // case RequestValidator.RequestValidatorResult.NotConfigured: // 許容しない
                 try
                 {
-                    var events = JsonSerializer.Deserialize(payloadBytes, AppJsonSerializerContext.Default.SendGridEventArray) ?? [];
+                    var events = JsonSerializer.Deserialize(payloadBytes, SendGridEventJsonContext.Default.SendGridEventArray) ?? [];
                     return (HttpStatusCode.OK, events);
                 }
                 catch (JsonException ex)

--- a/SendgridParquetLogger/Models/AppJsonSerializerContext.cs
+++ b/SendgridParquetLogger/Models/AppJsonSerializerContext.cs
@@ -1,9 +1,0 @@
-﻿using System.Text.Json.Serialization;
-
-namespace SendgridParquetLogger.Models;
-
-[JsonSerializable(typeof(SendgridParquet.Shared.SendGridEvent[]))]
-[JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Default, PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
-public partial class AppJsonSerializerContext : JsonSerializerContext
-{
-}

--- a/SendgridParquetLogger/Program.cs
+++ b/SendgridParquetLogger/Program.cs
@@ -1,7 +1,5 @@
 ﻿using SendgridParquet.Shared;
 
-using SendgridParquetLogger.Helper;
-
 using ZLogger;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/SendgridParquetViewer/Controllers/WebhookController.cs
+++ b/SendgridParquetViewer/Controllers/WebhookController.cs
@@ -1,14 +1,16 @@
-﻿#if UseSwagger
-using System.Net;
+﻿using System.Net;
 
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 using SendgridParquet.Shared;
 
-namespace SendgridParquetLogger.Controllers;
+namespace SendgridParquetViewer.Controllers;
 
 [ApiController]
 [Route("webhook")]
+[AllowAnonymous]
+[IgnoreAntiforgeryToken]
 public class WebhookController(
     WebhookHelper webhookHelper
 ) : ControllerBase
@@ -33,4 +35,3 @@ public class WebhookController(
         return StatusCode((int)status);
     }
 }
-#endif

--- a/SendgridParquetViewer/Program.cs
+++ b/SendgridParquetViewer/Program.cs
@@ -89,6 +89,12 @@ builder.Services.AddOptions<SendgridOptions>()
     .ValidateDataAnnotations()
     .ValidateOnStart();
 
+// Configure SendGrid webhook receive options (shared with Logger)
+builder.Services.AddOptions<SendGridOptions>()
+    .Bind(builder.Configuration.GetSection(SendGridOptions.SectionName))
+    .ValidateDataAnnotations()
+    .ValidateOnStart();
+
 //builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddOptions<TimeProviderOptions>()
     .Configure(options =>
@@ -123,6 +129,14 @@ builder.Services.AddHttpClient<ISendgridTemplateService, SendgridTemplateService
 
 // Add Parquet service
 builder.Services.AddSingleton<ParquetService>(); // 無状態のため AddSingleton
+
+// Webhook receive services (shared with Logger)
+builder.Services.AddSingleton<RequestValidator>(); // 無状態 PublicKey 生成をキャッシュするため AddSingleton
+builder.Services.AddScoped<WebhookHelper>();
+
+// Ensure S3 bucket exists at startup (Logger インスタンス廃止予定のため Viewer 単独でもバケット保証する)
+// Compaction HostedService より前に登録して先に動かす
+builder.Services.AddHostedService<CreateBucketService>();
 
 // Add Compaction service
 builder.Services.AddSingleton<CompactionService>(); // 1プロセスあたり同時実行は1つだけにする

--- a/SendgridParquetViewer/appsettings.json
+++ b/SendgridParquetViewer/appsettings.json
@@ -23,6 +23,7 @@
     "BUCKETNAME": "sendgrid-events"
   },
   "SENDGRID": {
-    "APIKEY": "get SendGrid API KEY (Dynamic Template 取得権限のあるもの)"
+    "APIKEY": "get SendGrid API KEY (Dynamic Template 取得権限のあるもの)",
+    "VERIFICATIONKEY": "get Verification key in https://app.sendgrid.com/settings/mail_settings/webhook_settings"
   }
 }


### PR DESCRIPTION
## Summary
- Logger (Sakura AppRun) インスタンス廃止予定に備え、Webhook 受信 (Parquet 変換 → S3 保存) を Viewer 側にも同一パス (`POST /webhook/sendgrid`) で提供
- `WebhookHelper` / `RequestValidator` / `CreateBucketService` を `SendgridParquet.Shared` に移動し Logger/Viewer 双方から参照 (git mv で履歴保持)
- `Shared.csproj` は `FrameworkReference` を使わず Abstractions 系 PackageReference のみ追加 (Logger の AOT/Alpine イメージサイズを維持)
- Viewer の `WebhookController` は `[AllowAnonymous]` + `[IgnoreAntiforgeryToken]` で認証/antiforgery をバイパス
- `CreateBucketService` は `CompactionStartupHostedService` より前に登録してバケット存在を先行保証
- `deploy.yml` / `SakuraCloud.sh` は既に `SENDGRID__VERIFICATIONKEY` を Viewer に渡しているため無変更で本番動作可

## Test plan
- [x] `dotnet build SendgridParquetLog.slnx` → 0 errors
- [x] `dotnet test SendgridParquetLogger.Test` → 7/7 passed (`RequestValidator` 移動後も全 PASS)
- [ ] ローカル起動 (Aspire) で `POST /webhook/sendgrid` が Viewer で 200/400 を返すことを curl で確認
- [ ] MinIO バケット (`sendgrid-events-dev`) に Parquet が書き込まれることを確認
- [ ] Logger 側 `/webhook/sendgrid` が引き続き動作することを確認
- [ ] Viewer の Blazor UI と `/health6QQl` が引き続き正常動作することを確認
- [ ] 本番デプロイ後、Sakura AppRun の Viewer で SendGrid 実配信 Webhook が受信できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)