### PR TITLE
SendgridParquetLogger のデプロイを停止

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,6 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      APP_NAME_SENDGRID_LOGGER: sendgridparquetlog-sendgrid-logger
       APP_NAME_SENDGRID_VIEWER: sendgridparquetlog-sendgrid-viewer
 
     steps:
@@ -35,67 +34,8 @@ jobs:
           username: ${{ vars.CONTAINER_REGISTRY_USERNAME }}
           password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
 
-      # ここから SendgridParquetLogger
-      - name: Extract metadata for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ vars.CONTAINER_REGISTRY_URL }}/${{ env.APP_NAME_SENDGRID_LOGGER }}
-          tags: |
-            type=raw,value=run_number${{ github.run_number }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./SendgridParquetLogger/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            VERSION=${{ env.VERSION }}
-            GITHUB_RUN_NUMBER=${{ github.run_number }}
-            GITHUB_SHA=${{ github.sha }}
-          # cache-from: type=gha
-          # cache-to: type=gha,mode=max
-
-      - name: Set Docker image URL for deployment
-        run: |
-          echo "DOCKER_FULL_IMAGE_URL=${{ steps.meta.outputs.tags }}" >> $GITHUB_ENV
-
-      - name: Deploy to Sakura Cloud
-        env:
-          SAKURACLOUD_ACCESS_TOKEN: ${{ vars.SAKURACLOUD_ACCESS_TOKEN }}
-          SAKURACLOUD_ACCESS_TOKEN_SECRET: ${{ secrets.SAKURACLOUD_ACCESS_TOKEN_SECRET }}
-          CONTAINER_REGISTRY_URL: ${{ vars.CONTAINER_REGISTRY_URL }}
-          CONTAINER_REGISTRY_USERNAME: ${{ vars.CONTAINER_REGISTRY_USERNAME }}
-          CONTAINER_REGISTRY_PASSWORD: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
-          S3__SERVICEURL: ${{ vars.S3__SERVICEURL }}
-          S3__REGION: ${{ vars.S3__REGION }}
-          S3__ACCESSKEY: ${{ vars.S3__ACCESSKEY }}
-          S3__SECRETKEY: ${{ secrets.S3__SECRETKEY }}
-          S3__BUCKETNAME: ${{ vars.S3__BUCKETNAME }}
-          SENDGRID__VERIFICATIONKEY: ${{ secrets.SENDGRID__VERIFICATIONKEY }}
-          SENDGRID__APIKEY: ${{ secrets.SENDGRID__APIKEY }}
-          AzureAD__Domain: ${{ vars.AZUREAD__DOMAIN }} # GitHub 側の設定は 大文字
-          AzureAD__TenantId: ${{ vars.AZUREAD__TENANTID }}
-          AzureAD__ClientId: ${{ vars.AZUREAD__CLIENTID }}
-          AzureAD__ClientSecret: ${{ secrets.AZUREAD__CLIENTSECRET }}
-          APP_NAME: ${{ env.APP_NAME_SENDGRID_LOGGER }}
-          APPRUN_PORT: "8080"
-          APPRUN_TIMEOUT: "180"
-          APPRUN_MAX_SCALE: "10"
-          # refer https://cloud.sakura.ad.jp/products/apprun-shared/
-          APPRUN_MAX_CPU: "0.5"
-          APPRUN_MAX_MEMORY: "1Gi"
-        run: |
-          echo "Deploying image: ${DOCKER_FULL_IMAGE_URL}"
-          bash ./Deploy/SakuraCloud.sh \
-            "${APP_NAME}" \
-            "${APPRUN_PORT}" \
-            "${DOCKER_FULL_IMAGE_URL}"
-
       # ここから SendgridParquetViewer
+      # SendgridParquetLogger は Webhook 受信機能を Viewer に集約したためデプロイを行わない
       - name: Extract metadata for Docker (Viewer)
         id: meta-viewer
         uses: docker/metadata-action@v5


### PR DESCRIPTION
## Summary
- Webhook 受信機能は #72 で `SendgridParquetViewer` に集約済み
- Logger 用の Sakura Cloud AppRun インスタンスは廃止 (最小インスタンスサイズ変更によるコスト増のため)
- `deploy.yml` から Logger 側の 4 ステップ (Docker metadata / build&push / image URL set / AppRun deploy) と未使用の `APP_NAME_SENDGRID_LOGGER` env を削除

## Test plan
- [ ] main マージ後、GitHub Actions で Viewer のデプロイのみが実行されることを確認
- [ ] Sakura Cloud 上の `sendgridparquetlog-sendgrid-logger` AppRun インスタンスを手動で削除 (本 PR のスコープ外、別作業)
- [ ] Viewer 側 `/webhook/sendgrid` で SendGrid からの Webhook を受信できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)