### PR TITLE
追加コンパクション (MoreCompaction) 画面で 1フォルダ1parquet へ手動統合

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,13 +22,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ vars.CONTAINER_REGISTRY_URL }}
           username: ${{ vars.CONTAINER_REGISTRY_USERNAME }}
@@ -38,14 +38,14 @@ jobs:
       # SendgridParquetLogger は Webhook 受信機能を Viewer に集約したためデプロイを行わない
       - name: Extract metadata for Docker (Viewer)
         id: meta-viewer
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ vars.CONTAINER_REGISTRY_URL }}/${{ env.APP_NAME_SENDGRID_VIEWER }}
           tags: |
             type=raw,value=run_number${{ github.run_number }}
 
       - name: Build and push Docker image (Viewer)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./SendgridParquetViewer/Dockerfile

--- a/SendgridParquet.Shared/S3StorageService.cs
+++ b/SendgridParquet.Shared/S3StorageService.cs
@@ -538,7 +538,9 @@ public class S3StorageService(
             var content = await ListObjectsAsync(new ListObjectsRequest(prefix, null, continuationToken), ct);
             if (string.IsNullOrEmpty(content))
             {
-                break;
+                throw new InvalidOperationException(
+                    $"Failed to list S3 objects for prefix '{prefix}'. ListObjectsAsync returned an empty response." +
+                    $"{(string.IsNullOrEmpty(continuationToken) ? string.Empty : $" ContinuationToken: '{continuationToken}'.")}");
             }
 
             XDocument doc = XDocument.Parse(content);

--- a/SendgridParquet.Shared/S3StorageService.cs
+++ b/SendgridParquet.Shared/S3StorageService.cs
@@ -222,6 +222,40 @@ public class S3StorageService(
         }
     }
 
+    /// <summary>
+    /// 指定した完全なオブジェクトキーが S3 に存在するかどうかを HEAD リクエストで判定する。
+    /// <see cref="AnyFileExistsAsync"/> は prefix 末尾に '/' を補って ListObjectsV2 を投げるため
+    /// 完全なキーには使えない ("key/" 以下のリストになり常に空になる)。キーそのものの存在確認には
+    /// こちらを使う。
+    /// </summary>
+    public async ValueTask<bool> ObjectExistsAsync(string key, CancellationToken ct)
+    {
+        var uri = GetObjectUri(key);
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Head, uri);
+            AddAwsSignatureHeaders(request, null);
+            using HttpResponseMessage response = await httpClient.SendAsync(request, ct);
+
+            if (response.IsSuccessStatusCode)
+            {
+                return true;
+            }
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                return false;
+            }
+            logger.ZLogWarning($"Unexpected status code {response.StatusCode} while HEAD {uri}; treating as not-exists");
+            return false;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
+        catch (Exception ex)
+        {
+            logger.ZLogError(ex, $"Error heading object {uri}");
+            return false;
+        }
+    }
+
     public async ValueTask<bool> DeleteObjectAsync(string key, CancellationToken ct)
     {
         var uri = GetObjectUri(key);

--- a/SendgridParquet.Shared/S3StorageService.cs
+++ b/SendgridParquet.Shared/S3StorageService.cs
@@ -21,6 +21,16 @@ public record S3GetObjectResult(byte[] Content, string? ETag);
 
 public readonly record struct S3ObjectEntry(string Key, long Size);
 
+/// <summary>
+/// 条件付き PUT の結果。
+/// </summary>
+public enum S3ConditionalPutResult
+{
+    Uploaded,
+    PreconditionFailed,
+    Failed,
+}
+
 public class S3StorageService(
     ILogger<S3StorageService> logger,
     IOptions<S3Options> options,
@@ -285,6 +295,49 @@ public class S3StorageService(
         {
             logger.ZLogError(ex, $"Error deleting object {uri} from S3");
             return false;
+        }
+    }
+
+    /// <summary>
+    /// If-None-Match: * を付けた Stream PUT。オブジェクトが存在しない場合のみ作成する。
+    /// 大容量 (マージ済み Parquet 等) を byte[] に読み込まずに送りたいケース向け。
+    /// </summary>
+    public async ValueTask<S3ConditionalPutResult> PutObjectIfNoneMatchAsync(string key, Stream content, CancellationToken ct)
+    {
+        var uri = GetObjectUri(key);
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Put, uri);
+            request.Headers.TryAddWithoutValidation("If-None-Match", "*");
+
+            AddAwsSignatureHeaders(request, content);
+
+            content.Seek(0, SeekOrigin.Begin);
+            request.Content = new StreamContent(content);
+            request.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/octet-stream");
+            using HttpResponseMessage response = await httpClient.SendAsync(request, ct);
+
+            if (response.IsSuccessStatusCode)
+            {
+                string? etag = response.Headers.ETag?.Tag;
+                logger.ZLogInformation($"Object {uri} uploaded conditionally (If-None-Match) to S3. ETag: {etag}");
+                return S3ConditionalPutResult.Uploaded;
+            }
+            if (response.StatusCode == HttpStatusCode.PreconditionFailed)
+            {
+                logger.ZLogInformation($"Conditional PUT failed for {uri} - precondition not met (object already exists)");
+                return S3ConditionalPutResult.PreconditionFailed;
+            }
+
+            string responseContent = await response.Content.ReadAsStringAsync(ct);
+            logger.ZLogError($"Error uploading object {uri} to S3. Status: {response.StatusCode}, Response: {ErrorContent(responseContent)}");
+            return S3ConditionalPutResult.Failed;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
+        catch (Exception ex)
+        {
+            logger.ZLogError(ex, $"Error uploading object {uri} to S3 (conditional stream)");
+            return S3ConditionalPutResult.Failed;
         }
     }
 

--- a/SendgridParquet.Shared/S3StorageService.cs
+++ b/SendgridParquet.Shared/S3StorageService.cs
@@ -19,6 +19,8 @@ namespace SendgridParquet.Shared;
 
 public record S3GetObjectResult(byte[] Content, string? ETag);
 
+public readonly record struct S3ObjectEntry(string Key, long Size);
+
 public class S3StorageService(
     ILogger<S3StorageService> logger,
     IOptions<S3Options> options,
@@ -388,6 +390,47 @@ public class S3StorageService(
                    .Select(cp => cp.Element(ns + "Key")?.Value!)
                    .Where(p => !string.IsNullOrEmpty(p))
             );
+
+            bool isTruncated = string.Equals(doc.Root?.Element(ns + "IsTruncated")?.Value, "true", StringComparison.OrdinalIgnoreCase);
+            continuationToken = isTruncated ? doc.Root?.Element(ns + "NextContinuationToken")?.Value : null;
+        } while (!string.IsNullOrEmpty(continuationToken));
+
+        return results;
+    }
+
+    /// <summary>
+    /// prefix 配下のオブジェクトを Key と Size の組で列挙する。
+    /// </summary>
+    public async ValueTask<IReadOnlyCollection<S3ObjectEntry>> ListFilesWithSizeAsync(string prefix, CancellationToken ct)
+    {
+        var results = new List<S3ObjectEntry>();
+        string? continuationToken = null;
+
+        do
+        {
+            if (ct.IsCancellationRequested)
+            {
+                break;
+            }
+            var content = await ListObjectsAsync(new ListObjectsRequest(prefix, null, continuationToken), ct);
+            if (string.IsNullOrEmpty(content))
+            {
+                break;
+            }
+
+            XDocument doc = XDocument.Parse(content);
+            XNamespace ns = doc.Root?.GetDefaultNamespace() ?? XNamespace.None;
+
+            foreach (XElement c in doc.Descendants(ns + "Contents"))
+            {
+                string? key = c.Element(ns + "Key")?.Value;
+                if (string.IsNullOrEmpty(key))
+                {
+                    continue;
+                }
+                long size = long.TryParse(c.Element(ns + "Size")?.Value, out long parsed) ? parsed : 0L;
+                results.Add(new S3ObjectEntry(key, size));
+            }
 
             bool isTruncated = string.Equals(doc.Root?.Element(ns + "IsTruncated")?.Value, "true", StringComparison.OrdinalIgnoreCase);
             continuationToken = isTruncated ? doc.Root?.Element(ns + "NextContinuationToken")?.Value : null;

--- a/SendgridParquet.Shared/S3StorageService.cs
+++ b/SendgridParquet.Shared/S3StorageService.cs
@@ -399,6 +399,42 @@ public class S3StorageService(
     }
 
     /// <summary>
+    /// prefix 配下の Parquet ファイル (.parquet 拡張子) のみを列挙する。
+    /// DuckDB や Compaction 処理に渡す前段で、morecompaction.json などの
+    /// 非 parquet オブジェクトを誤って対象にしないためのガード。
+    /// </summary>
+    public async ValueTask<IReadOnlyCollection<string>> ListParquetFilesAsync(string prefix, CancellationToken ct)
+    {
+        var all = await ListFilesAsync(prefix, ct);
+        var results = new List<string>(all.Count);
+        foreach (string key in all)
+        {
+            if (key.EndsWith(SendGridPathUtility.ParquetFileExtension, StringComparison.OrdinalIgnoreCase))
+            {
+                results.Add(key);
+            }
+        }
+        return results;
+    }
+
+    /// <summary>
+    /// prefix 配下の Parquet ファイル (.parquet 拡張子) のみを Key と Size の組で列挙する。
+    /// </summary>
+    public async ValueTask<IReadOnlyCollection<S3ObjectEntry>> ListParquetFilesWithSizeAsync(string prefix, CancellationToken ct)
+    {
+        var all = await ListFilesWithSizeAsync(prefix, ct);
+        var results = new List<S3ObjectEntry>(all.Count);
+        foreach (S3ObjectEntry entry in all)
+        {
+            if (entry.Key.EndsWith(SendGridPathUtility.ParquetFileExtension, StringComparison.OrdinalIgnoreCase))
+            {
+                results.Add(entry);
+            }
+        }
+        return results;
+    }
+
+    /// <summary>
     /// prefix 配下のオブジェクトを Key と Size の組で列挙する。
     /// </summary>
     public async ValueTask<IReadOnlyCollection<S3ObjectEntry>> ListFilesWithSizeAsync(string prefix, CancellationToken ct)

--- a/SendgridParquet.Shared/SendGridPathUtility.cs
+++ b/SendgridParquet.Shared/SendGridPathUtility.cs
@@ -160,4 +160,29 @@ public static class SendGridPathUtility
 
     public static (string runJsonPath, string lockPath) GetS3CompactionRunFile() =>
         ($"{FolderPrefixCompaction}/run.json", $"{FolderPrefixCompaction}/run.lock");
+
+    /// <summary>
+    /// 追加コンパクション (MoreCompaction) の出力ファイル名。
+    /// 1 フォルダ 1 ファイル保証時の固定名。
+    /// </summary>
+    public const string MoreCompactionFileName = "morecompaction" + ParquetFileExtension;
+
+    /// <summary>
+    /// 追加コンパクションの完了を示す JSON のファイル名。
+    /// </summary>
+    public const string MoreCompactionStatusFileName = "morecompaction.json";
+
+    /// <summary>
+    /// 追加コンパクションの出力 Parquet の S3 キー。
+    /// 対象 yyyy/MM/dd/HH フォルダの直下に固定名で配置する。
+    /// </summary>
+    public static string GetS3MoreCompactionParquetKey(int year, int month, int day, int hour) =>
+        $"{FolderPrefixCompaction}{GetYmdhPrefix(year, month, day, hour)}/{MoreCompactionFileName}";
+
+    /// <summary>
+    /// 年月単位での完了マーカー JSON の S3 キー。
+    /// 存在すれば その年月の全フォルダが 1 parquet 保証済み。
+    /// </summary>
+    public static string GetS3MoreCompactionStatusKey(int year, int month) =>
+        $"{FolderPrefixCompaction}{GetYmdhPrefix(year, month, null, null)}/{MoreCompactionStatusFileName}";
 }

--- a/SendgridParquet.Shared/SendGridPathUtility.cs
+++ b/SendgridParquet.Shared/SendGridPathUtility.cs
@@ -163,9 +163,10 @@ public static class SendGridPathUtility
 
     /// <summary>
     /// 追加コンパクション (MoreCompaction) の出力ファイル名。
-    /// 1 フォルダ 1 ファイル保証時の固定名。
+    /// フォルダをまたいでも一意になるように yyyyMMddHH を含める。
     /// </summary>
-    public const string MoreCompactionFileName = "morecompaction" + ParquetFileExtension;
+    public static string GetMoreCompactionFileName(int year, int month, int day, int hour) =>
+        $"compaction{year:D4}{month:D2}{day:D2}{hour:D2}{ParquetFileExtension}";
 
     /// <summary>
     /// 追加コンパクションの完了を示す JSON のファイル名。
@@ -174,10 +175,10 @@ public static class SendGridPathUtility
 
     /// <summary>
     /// 追加コンパクションの出力 Parquet の S3 キー。
-    /// 対象 yyyy/MM/dd/HH フォルダの直下に固定名で配置する。
+    /// 対象 yyyy/MM/dd/HH フォルダの直下に yyyyMMddHH を含むユニークな名前で配置する。
     /// </summary>
     public static string GetS3MoreCompactionParquetKey(int year, int month, int day, int hour) =>
-        $"{FolderPrefixCompaction}{GetYmdhPrefix(year, month, day, hour)}/{MoreCompactionFileName}";
+        $"{FolderPrefixCompaction}{GetYmdhPrefix(year, month, day, hour)}/{GetMoreCompactionFileName(year, month, day, hour)}";
 
     /// <summary>
     /// 年月単位での完了マーカー JSON の S3 キー。

--- a/SendgridParquet.Shared/SendGridPathUtility.cs
+++ b/SendgridParquet.Shared/SendGridPathUtility.cs
@@ -163,10 +163,11 @@ public static class SendGridPathUtility
 
     /// <summary>
     /// 追加コンパクション (MoreCompaction) の出力ファイル名。
-    /// フォルダをまたいでも一意になるように yyyyMMddHH を含める。
+    /// 通常 Compaction 出力 (ハッシュ名) と一目で区別できるよう `morecompaction` プレフィックスを付け、
+    /// フォルダをまたいでも一意になるよう yyyyMMddHH を含める。
     /// </summary>
     public static string GetMoreCompactionFileName(int year, int month, int day, int hour) =>
-        $"compaction{year:D4}{month:D2}{day:D2}{hour:D2}{ParquetFileExtension}";
+        $"morecompaction{year:D4}{month:D2}{day:D2}{hour:D2}{ParquetFileExtension}";
 
     /// <summary>
     /// 追加コンパクションの完了を示す JSON のファイル名。

--- a/SendgridParquetViewer/Components/Layout/NavMenu.razor
+++ b/SendgridParquetViewer/Components/Layout/NavMenu.razor
@@ -23,6 +23,11 @@
                 <span class="bi bi-archive-fill-nav-menu" aria-hidden="true"></span> Compaction
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="more-compaction">
+                <span class="bi bi-archive-fill-nav-menu" aria-hidden="true"></span> 追加コンパクション
+            </NavLink>
+        </div>
     </nav>
 </div>
 

--- a/SendgridParquetViewer/Components/Layout/NavMenu.razor
+++ b/SendgridParquetViewer/Components/Layout/NavMenu.razor
@@ -25,7 +25,7 @@
         </div>
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="more-compaction">
-                <span class="bi bi-archive-fill-nav-menu" aria-hidden="true"></span> 追加コンパクション
+                <span class="bi bi-archive-fill-nav-menu" aria-hidden="true"></span> MoreCompaction
             </NavLink>
         </div>
     </nav>

--- a/SendgridParquetViewer/Components/Pages/Histogram.razor
+++ b/SendgridParquetViewer/Components/Pages/Histogram.razor
@@ -223,7 +223,7 @@
             _ => throw new ArgumentOutOfRangeException()
         };
         var s3CompactionPrefix = SendGridPathUtility.GetS3CompactionPrefix(ymd.Year, ymd.Month, ymd.Day, ymd.Hour);
-        var keys = await S3StorageService.ListFilesAsync(s3CompactionPrefix, ct);
+        var keys = await S3StorageService.ListParquetFilesAsync(s3CompactionPrefix, ct);
         var pathPrefix = S3PresigningTransformer.PathPrefix;
         return keys.Select(x => $"{pathPrefix}/{x}").ToArray();
     }

--- a/SendgridParquetViewer/Components/Pages/Home.razor
+++ b/SendgridParquetViewer/Components/Pages/Home.razor
@@ -251,7 +251,7 @@
             _ => throw new ArgumentOutOfRangeException()
         };
         var s3CompactionPrefix = SendGridPathUtility.GetS3CompactionPrefix(ymd.Year, ymd.Month, ymd.Day, ymd.Hour);
-        var keys = await S3StorageService.ListFilesAsync(s3CompactionPrefix, ct);
+        var keys = await S3StorageService.ListParquetFilesAsync(s3CompactionPrefix, ct);
         var pathPrefix = S3PresigningTransformer.PathPrefix;
         return keys.Select(x => $"{pathPrefix}/{x}").ToArray();
     }

--- a/SendgridParquetViewer/Components/Pages/MoreCompaction.razor
+++ b/SendgridParquetViewer/Components/Pages/MoreCompaction.razor
@@ -46,6 +46,34 @@
         }
     </FluentStack>
 
+    @if (_isScanning)
+    {
+        <FluentStack Orientation="Orientation.Horizontal" VerticalAlignment="VerticalAlignment.Center" Style="gap: 0.75em; margin-top: 0.5em;">
+            <FluentProgressRing Style="width: 1.25em; height: 1.25em;" />
+            <FluentLabel>
+                @if (_scanProgress is { } sp)
+                {
+                    <small>
+                        スキャン中:
+                        @if (sp.CurrentDay is { } d)
+                        {
+                            @($"{_selectedYear}/{_selectedMonth:D2}/{d:D2}")
+                        }
+                        else
+                        {
+                            <span>準備中</span>
+                        }
+                        (@sp.ProcessedDays / @sp.TotalDays 日 完了, 対象フォルダ @sp.MultiFileFoldersFound 件)
+                    </small>
+                }
+                else
+                {
+                    <small>スキャン中: 準備中</small>
+                }
+            </FluentLabel>
+        </FluentStack>
+    }
+
     @if (!string.IsNullOrEmpty(_message))
     {
         <div style="margin-top: 1em;">
@@ -73,6 +101,10 @@
             <p>
                 全 <strong>@_scan.TotalHourFolders</strong> 件の yyyy/MM/dd/HH フォルダを確認しました。<br />
                 Parquet が 2 つ以上あるフォルダ: <strong>@_scan.MultiFileFolders.Count</strong> 件
+                @if (_scan.MultiFileFolders.Count != _remainingFolders.Count)
+                {
+                    <span>(残り <strong>@_remainingFolders.Count</strong> 件)</span>
+                }
             </p>
 
             @if (_scan.MultiFileFolders.Count == 0)
@@ -102,39 +134,49 @@
                     </FluentMessageBar>
                 }
 
-                <table class="more-compaction-table">
-                    <thead>
-                        <tr>
-                            <th>日/時</th>
-                            <th>parquet 数</th>
-                            <th>合計サイズ</th>
-                            <th>操作</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        @foreach (var folder in _scan.MultiFileFolders)
-                        {
-                            <tr>
-                                <td>@($"{folder.Day:D2}") / @($"{folder.Hour:D2}")</td>
-                                <td>@folder.ParquetFiles.Count</td>
-                                <td>@FormatBytes(folder.TotalBytes)</td>
-                                <td>
-                                    <FluentButton Appearance="Appearance.Neutral"
-                                                  OnClick="@(() => OnRunFolderClickedAsync(folder))"
-                                                  Disabled="@_isRunning">
-                                        実行
-                                    </FluentButton>
-                                </td>
-                            </tr>
-                        }
-                    </tbody>
-                </table>
-
-                <div style="margin-top: 1em;">
-                    <FluentButton Appearance="Appearance.Accent" OnClick="OnRunAllClickedAsync" Disabled="@_isRunning">
-                        @(_isRunning ? "実行中..." : "すべて実行")
+                @if (_remainingFolders.Count == 0)
+                {
+                    <p>すべての対象フォルダの統合が完了しました。完了マーカーを書き込めます。</p>
+                    <FluentButton Appearance="Appearance.Accent" OnClick="OnWriteStatusClickedAsync" Disabled="@_isRunning">
+                        完了マーカーを書き込む
                     </FluentButton>
-                </div>
+                }
+                else
+                {
+                    <table class="more-compaction-table">
+                        <thead>
+                            <tr>
+                                <th>日/時</th>
+                                <th>parquet 数</th>
+                                <th>合計サイズ</th>
+                                <th>操作</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var folder in _remainingFolders)
+                            {
+                                <tr @key="folder.Prefix">
+                                    <td>@($"{folder.Day:D2}") / @($"{folder.Hour:D2}")</td>
+                                    <td>@folder.ParquetFiles.Count</td>
+                                    <td>@FormatBytes(folder.TotalBytes)</td>
+                                    <td>
+                                        <FluentButton Appearance="Appearance.Neutral"
+                                                      OnClick="@(() => OnRunFolderClickedAsync(folder))"
+                                                      Disabled="@_isRunning">
+                                            実行
+                                        </FluentButton>
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+
+                    <div style="margin-top: 1em;">
+                        <FluentButton Appearance="Appearance.Accent" OnClick="OnRunAllClickedAsync" Disabled="@_isRunning">
+                            @(_isRunning ? "実行中..." : "すべて実行")
+                        </FluentButton>
+                    </div>
+                }
             }
         </FluentCard>
     }
@@ -179,6 +221,8 @@
     private MoreCompactionStatus? _status;
     private MoreCompactionService.ScanResult? _scan;
     private MoreCompactionService.DiskSpaceEstimate? _diskEstimate;
+    private MoreCompactionService.ScanProgress? _scanProgress;
+    private List<MoreCompactionService.HourFolder> _remainingFolders = [];
 
     private string _message = string.Empty;
     private MessageIntent _messageIntent = MessageIntent.Info;
@@ -229,6 +273,8 @@
         _scan = null;
         _diskEstimate = null;
         _scanCompleted = false;
+        _scanProgress = null;
+        _remainingFolders = [];
         _runLog.Clear();
         _message = string.Empty;
 
@@ -242,9 +288,15 @@
                 return;
             }
 
-            MoreCompactionService.ScanResult scan = await MoreCompactionService.ScanAsync(_selectedYear, _selectedMonth, _cts.Token);
+            var progress = new Progress<MoreCompactionService.ScanProgress>(p =>
+            {
+                _scanProgress = p;
+                StateHasChanged();
+            });
+            MoreCompactionService.ScanResult scan = await MoreCompactionService.ScanAsync(_selectedYear, _selectedMonth, _cts.Token, progress);
             _scan = scan;
             _scanCompleted = true;
+            _remainingFolders = [.. scan.MultiFileFolders];
             _diskEstimate = MoreCompactionService.EstimateDiskSpace(scan.MaxTempBytesPerFolder);
 
             if (scan.TotalHourFolders == 0)
@@ -272,6 +324,7 @@
         finally
         {
             _isScanning = false;
+            _scanProgress = null;
         }
     }
 
@@ -337,6 +390,8 @@
                     else
                     {
                         AppendLog($"{label} 完了 events={result.TotalEvents} 元ファイル削除={result.DeletedFiles}");
+                        _remainingFolders.Remove(folder);
+                        StateHasChanged();
                     }
                 }
                 catch (OperationCanceledException)
@@ -350,24 +405,6 @@
                     AppendLog($"{label} 失敗: {ex.Message}");
                 }
             }
-
-            // 実行後に再スキャンして最新状態を反映するが、実行ログは保持する
-            List<string> existingRunLog = [.. _runLog];
-            string? existingMessage = _message;
-            MessageIntent existingMessageIntent = _messageIntent;
-
-            await OnScanClickedAsync();
-
-            _runLog.Clear();
-            _runLog.AddRange(existingRunLog);
-
-            if (string.IsNullOrEmpty(_message) && !string.IsNullOrEmpty(existingMessage))
-            {
-                _message = existingMessage;
-                _messageIntent = existingMessageIntent;
-            }
-
-            StateHasChanged();
         }
         finally
         {

--- a/SendgridParquetViewer/Components/Pages/MoreCompaction.razor
+++ b/SendgridParquetViewer/Components/Pages/MoreCompaction.razor
@@ -64,16 +64,7 @@
                 @if (_scanProgress is { } sp)
                 {
                     <small>
-                        スキャン中:
-                        @if (sp.CurrentDay is { } d && _selectedDate is { } sd)
-                        {
-                            @($"{sd.Year}/{sd.Month:D2}/{d:D2}")
-                        }
-                        else
-                        {
-                            <span>準備中</span>
-                        }
-                        (@sp.ProcessedDays / @sp.TotalDays 日 完了, 対象フォルダ @sp.MultiFileFoldersFound 件)
+                        スキャン中: @sp.ProcessedDays / @sp.TotalDays 日 完了, 対象フォルダ @sp.MultiFileFoldersFound 件
                     </small>
                 }
                 else

--- a/SendgridParquetViewer/Components/Pages/MoreCompaction.razor
+++ b/SendgridParquetViewer/Components/Pages/MoreCompaction.razor
@@ -26,7 +26,7 @@
     </p>
     <p>
         <small>
-            出力ファイル名は固定 (<code>@SendGridPathUtility.MoreCompactionFileName</code>) です。
+            出力ファイル名は <code>compaction&lt;yyyyMMddHH&gt;.parquet</code> で、フォルダをまたいでも一意になります。
             処理中断の耐性のためアップロード前に同名ファイルを削除してから書き込みます。
             完了マーカー <code>@SendGridPathUtility.MoreCompactionStatusFileName</code> が年月フォルダ直下に存在する場合は処理済みとして先に進みません。
         </small>

--- a/SendgridParquetViewer/Components/Pages/MoreCompaction.razor
+++ b/SendgridParquetViewer/Components/Pages/MoreCompaction.razor
@@ -1,0 +1,396 @@
+@page "/more-compaction"
+@rendermode InteractiveServer
+@attribute [Authorize]
+@using SendgridParquet.Shared
+@using SendgridParquetViewer.Models
+@using SendgridParquetViewer.Services
+@using ZLogger
+@implements IDisposable
+@inject ILogger<MoreCompaction> Logger
+@inject MoreCompactionService MoreCompactionService
+@inject TimeProvider TimeProvider
+
+<PageTitle>追加コンパクション</PageTitle>
+
+<FluentCard class="main-card">
+    <FluentHeader>
+        <FluentSpacer />
+        <FluentLabel Typo="Typography.PageTitle">追加コンパクション</FluentLabel>
+        <FluentSpacer />
+    </FluentHeader>
+
+    <p>
+        通常の Compaction 処理が途中で失敗すると、<code>v3compaction/yyyy/MM/dd/HH</code> フォルダに
+        複数の Parquet ファイルが残ることがあります。この画面では年月単位で対象フォルダを洗い出し、
+        1 フォルダ 1 Parquet ファイルへ統合します。
+    </p>
+    <p>
+        <small>
+            出力ファイル名は固定 (<code>@SendGridPathUtility.MoreCompactionFileName</code>) です。
+            処理中断の耐性のためアップロード前に同名ファイルを削除してから書き込みます。
+            完了マーカー <code>@SendGridPathUtility.MoreCompactionStatusFileName</code> が年月フォルダ直下に存在する場合は処理済みとして先に進みません。
+        </small>
+    </p>
+
+    <FluentStack Orientation="Orientation.Horizontal" VerticalAlignment="VerticalAlignment.Center" Style="gap: 1em; flex-wrap: wrap;">
+        <FluentNumberField TValue="int" @bind-Value="_selectedYear" Label="年" Min="2000" Max="2999" Style="width: 8em;" />
+        <FluentNumberField TValue="int" @bind-Value="_selectedMonth" Label="月" Min="1" Max="12" Style="width: 8em;" />
+        <FluentButton Appearance="Appearance.Accent" OnClick="OnScanClickedAsync" Disabled="@(_isScanning || _isRunning)">
+            @(_isScanning ? "スキャン中..." : "スキャン")
+        </FluentButton>
+        @if (_maxSelectable is { } maxSel)
+        {
+            <FluentLabel>
+                <small>選択可能な最新年月: @maxSel.Year / @($"{maxSel.Month:D2}")</small>
+            </FluentLabel>
+        }
+    </FluentStack>
+
+    @if (!string.IsNullOrEmpty(_message))
+    {
+        <div style="margin-top: 1em;">
+            <FluentMessageBar Intent="@_messageIntent" OnDismiss="() => _message = string.Empty">
+                @_message
+            </FluentMessageBar>
+        </div>
+    }
+
+    @if (_status != null)
+    {
+        <FluentCard style="margin-top: 1em;">
+            <p>
+                <strong>処理完了済み</strong><br />
+                @_status.Year / @($"{_status.Month:D2}") について 1 フォルダ 1 Parquet であることが保証されています。<br />
+                完了時刻: @_status.CompletedAt.ToJst().ToString("yyyy/MM/dd HH:mm:ss") JST<br />
+                確認対象フォルダ数: @_status.VerifiedHourFolders
+            </p>
+        </FluentCard>
+    }
+    else if (_scanCompleted && _scan != null)
+    {
+        <FluentCard style="margin-top: 1em;">
+            <h3>スキャン結果: @_scan.Year / @($"{_scan.Month:D2}")</h3>
+            <p>
+                全 <strong>@_scan.TotalHourFolders</strong> 件の yyyy/MM/dd/HH フォルダを確認しました。<br />
+                Parquet が 2 つ以上あるフォルダ: <strong>@_scan.MultiFileFolders.Count</strong> 件
+            </p>
+
+            @if (_scan.MultiFileFolders.Count == 0)
+            {
+                @if (_scan.TotalHourFolders == 0)
+                {
+                    <p>この年月に対象フォルダは存在しません。</p>
+                }
+                else
+                {
+                    <p>すべてのフォルダが 1 parquet のみです。完了マーカーを書き込みます。</p>
+                    <FluentButton Appearance="Appearance.Accent" OnClick="OnWriteStatusClickedAsync" Disabled="@_isRunning">
+                        完了マーカーを書き込む
+                    </FluentButton>
+                }
+            }
+            else
+            {
+                <p>
+                    実行時の想定最大ディスク消費量 (1 フォルダあたり): <strong>@FormatBytes(_scan.MaxTempBytesPerFolder)</strong><br />
+                    一時フォルダ: <code>@_diskEstimate?.TempPath</code> 空き容量: <strong>@FormatBytes(_diskEstimate?.AvailableFreeBytes ?? 0)</strong>
+                </p>
+                @if (_diskEstimate is { IsSufficient: false })
+                {
+                    <FluentMessageBar Intent="MessageIntent.Warning">
+                        一時フォルダの空き容量が不足している可能性があります。処理を開始する前に十分な空き容量を確保してください。
+                    </FluentMessageBar>
+                }
+
+                <table class="more-compaction-table">
+                    <thead>
+                        <tr>
+                            <th>日/時</th>
+                            <th>parquet 数</th>
+                            <th>合計サイズ</th>
+                            <th>操作</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var folder in _scan.MultiFileFolders)
+                        {
+                            <tr>
+                                <td>@($"{folder.Day:D2}") / @($"{folder.Hour:D2}")</td>
+                                <td>@folder.ParquetFiles.Count</td>
+                                <td>@FormatBytes(folder.TotalBytes)</td>
+                                <td>
+                                    <FluentButton Appearance="Appearance.Neutral"
+                                                  OnClick="@(() => OnRunFolderClickedAsync(folder))"
+                                                  Disabled="@_isRunning">
+                                        実行
+                                    </FluentButton>
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+
+                <div style="margin-top: 1em;">
+                    <FluentButton Appearance="Appearance.Accent" OnClick="OnRunAllClickedAsync" Disabled="@_isRunning">
+                        @(_isRunning ? "実行中..." : "すべて実行")
+                    </FluentButton>
+                </div>
+            }
+        </FluentCard>
+    }
+
+    @if (_runLog.Count > 0)
+    {
+        <FluentCard style="margin-top: 1em;">
+            <h3>実行ログ</h3>
+            <pre style="white-space: pre-wrap;">@string.Join(Environment.NewLine, _runLog)</pre>
+        </FluentCard>
+    }
+</FluentCard>
+
+<style>
+    .more-compaction-table {
+        border-collapse: collapse;
+        width: 100%;
+        margin-top: 0.5rem;
+    }
+
+        .more-compaction-table th,
+        .more-compaction-table td {
+            border: 1px solid #d0d7de;
+            padding: 0.4rem 0.75rem;
+            text-align: left;
+        }
+
+        .more-compaction-table th {
+            background-color: #f6f8fa;
+        }
+</style>
+
+@code {
+    private int _selectedYear;
+    private int _selectedMonth;
+    private (int Year, int Month)? _maxSelectable;
+
+    private bool _isScanning;
+    private bool _isRunning;
+    private bool _scanCompleted;
+
+    private MoreCompactionStatus? _status;
+    private MoreCompactionService.ScanResult? _scan;
+    private MoreCompactionService.DiskSpaceEstimate? _diskEstimate;
+
+    private string _message = string.Empty;
+    private MessageIntent _messageIntent = MessageIntent.Info;
+    private readonly List<string> _runLog = new();
+    private readonly CancellationTokenSource _cts = new();
+
+    protected override void OnInitialized()
+    {
+        DateTimeOffset nowJst = TimeProvider.GetUtcNow().ToJst();
+        // 選択可能な最新年月 = 今月の 1 つ前
+        DateTimeOffset previousMonth = nowJst.AddMonths(-1);
+        _maxSelectable = (previousMonth.Year, previousMonth.Month);
+        _selectedYear = previousMonth.Year;
+        _selectedMonth = previousMonth.Month;
+    }
+
+    private bool ValidateSelection()
+    {
+        if (_maxSelectable is not { } maxSel)
+        {
+            ShowMessage("選択可能年月の算出に失敗しました。", MessageIntent.Error);
+            return false;
+        }
+
+        int selected = _selectedYear * 100 + _selectedMonth;
+        int max = maxSel.Year * 100 + maxSel.Month;
+        if (_selectedMonth is < 1 or > 12)
+        {
+            ShowMessage("月は 1 から 12 の範囲で指定してください。", MessageIntent.Error);
+            return false;
+        }
+        if (selected > max)
+        {
+            ShowMessage($"先月以前の年月のみ指定できます (最新: {maxSel.Year}/{maxSel.Month:D2})。", MessageIntent.Warning);
+            return false;
+        }
+        return true;
+    }
+
+    private async Task OnScanClickedAsync()
+    {
+        if (!ValidateSelection())
+        {
+            return;
+        }
+
+        _status = null;
+        _scan = null;
+        _diskEstimate = null;
+        _scanCompleted = false;
+        _runLog.Clear();
+        _message = string.Empty;
+
+        _isScanning = true;
+        try
+        {
+            _status = await MoreCompactionService.GetStatusAsync(_selectedYear, _selectedMonth, _cts.Token);
+            if (_status != null)
+            {
+                ShowMessage("処理完了済みのためスキャンを実施しません。", MessageIntent.Info);
+                return;
+            }
+
+            MoreCompactionService.ScanResult scan = await MoreCompactionService.ScanAsync(_selectedYear, _selectedMonth, _cts.Token);
+            _scan = scan;
+            _scanCompleted = true;
+            _diskEstimate = MoreCompactionService.EstimateDiskSpace(scan.MaxTempBytesPerFolder);
+
+            if (scan.TotalHourFolders == 0)
+            {
+                ShowMessage("この年月に対象フォルダは存在しません。", MessageIntent.Info);
+            }
+            else if (scan.MultiFileFolders.Count == 0)
+            {
+                ShowMessage("すべてのフォルダが 1 parquet のみです。完了マーカーを書き込めます。", MessageIntent.Success);
+            }
+            else
+            {
+                ShowMessage($"{scan.MultiFileFolders.Count} 件の対象フォルダが見つかりました。", MessageIntent.Info);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // ページ破棄時のキャンセル
+        }
+        catch (Exception ex)
+        {
+            Logger.ZLogError(ex, $"Scan failed {_selectedYear}/{_selectedMonth}");
+            ShowMessage("スキャンに失敗しました。", MessageIntent.Error);
+        }
+        finally
+        {
+            _isScanning = false;
+        }
+    }
+
+    private async Task OnWriteStatusClickedAsync()
+    {
+        if (_scan == null)
+        {
+            return;
+        }
+
+        _isRunning = true;
+        try
+        {
+            _status = await MoreCompactionService.WriteStatusAsync(
+                _scan.Year, _scan.Month, _scan.TotalHourFolders, _cts.Token);
+            ShowMessage("完了マーカーを書き込みました。", MessageIntent.Success);
+        }
+        catch (Exception ex)
+        {
+            Logger.ZLogError(ex, $"Write status failed {_scan.Year}/{_scan.Month}");
+            ShowMessage("完了マーカーの書き込みに失敗しました。", MessageIntent.Error);
+        }
+        finally
+        {
+            _isRunning = false;
+        }
+    }
+
+    private async Task OnRunFolderClickedAsync(MoreCompactionService.HourFolder folder)
+    {
+        await RunFoldersAsync(new[] { folder });
+    }
+
+    private async Task OnRunAllClickedAsync()
+    {
+        if (_scan == null)
+        {
+            return;
+        }
+        await RunFoldersAsync(_scan.MultiFileFolders);
+    }
+
+    private async Task RunFoldersAsync(IReadOnlyList<MoreCompactionService.HourFolder> folders)
+    {
+        _isRunning = true;
+        try
+        {
+            foreach (MoreCompactionService.HourFolder folder in folders)
+            {
+                if (_cts.IsCancellationRequested)
+                {
+                    break;
+                }
+                string label = $"{folder.Year}/{folder.Month:D2}/{folder.Day:D2}/{folder.Hour:D2}";
+                AppendLog($"{label} 実行開始 (files={folder.ParquetFiles.Count}, size={FormatBytes(folder.TotalBytes)})");
+                try
+                {
+                    MoreCompactionFolderResult result = await MoreCompactionService.ExecuteFolderAsync(folder, _cts.Token);
+                    if (result.Skipped)
+                    {
+                        AppendLog($"{label} スキップ");
+                    }
+                    else
+                    {
+                        AppendLog($"{label} 完了 events={result.TotalEvents} 元ファイル削除={result.DeletedFiles}");
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    AppendLog($"{label} キャンセル");
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    Logger.ZLogError(ex, $"MoreCompaction folder failed: {label}");
+                    AppendLog($"{label} 失敗: {ex.Message}");
+                }
+            }
+
+            // 実行後に再スキャンして最新状態を反映する
+            await OnScanClickedAsync();
+        }
+        finally
+        {
+            _isRunning = false;
+        }
+    }
+
+    private void AppendLog(string line)
+    {
+        string timestamp = TimeProvider.GetUtcNow().ToJst().ToString("HH:mm:ss");
+        _runLog.Add($"[{timestamp}] {line}");
+        StateHasChanged();
+    }
+
+    private void ShowMessage(string msg, MessageIntent intent)
+    {
+        _message = msg;
+        _messageIntent = intent;
+        StateHasChanged();
+    }
+
+    private static string FormatBytes(long bytes)
+    {
+        const long scale = 1024;
+        string[] orders = ["B", "KB", "MB", "GB", "TB", "PB"];
+        double value = bytes;
+        int idx = 0;
+        while (value >= scale && idx < orders.Length - 1)
+        {
+            value /= scale;
+            idx++;
+        }
+        return FormattableString.Invariant($"{value:0.##} {orders[idx]}");
+    }
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+        _cts.Dispose();
+    }
+}

--- a/SendgridParquetViewer/Components/Pages/MoreCompaction.razor
+++ b/SendgridParquetViewer/Components/Pages/MoreCompaction.razor
@@ -28,7 +28,8 @@
     <p>
         <small>
             出力ファイル名は <code>morecompaction&lt;yyyyMMddHH&gt;.parquet</code> で、通常 Compaction 出力と区別でき、フォルダをまたいでも一意になります。
-            処理中断時の安全性を優先し、同名ファイルを事前削除せずに書き込み可否を確認しながら処理します。
+            書き込みは条件付き PUT (<code>If-None-Match</code>) で行い、既存の同名ファイルを上書きしません。
+            既に同名ファイルがある場合は削除せずに内容を検証し、元ソースの削除のみ実施します。
             完了マーカー <code>@SendGridPathUtility.MoreCompactionStatusFileName</code> が年月フォルダ直下に存在する場合は処理済みとして先に進みません。
         </small>
     </p>

--- a/SendgridParquetViewer/Components/Pages/MoreCompaction.razor
+++ b/SendgridParquetViewer/Components/Pages/MoreCompaction.razor
@@ -28,7 +28,7 @@
     <p>
         <small>
             出力ファイル名は <code>morecompaction&lt;yyyyMMddHH&gt;.parquet</code> で、通常 Compaction 出力と区別でき、フォルダをまたいでも一意になります。
-            処理中断の耐性のためアップロード前に同名ファイルを削除してから書き込みます。
+            処理中断時の安全性を優先し、同名ファイルを事前削除せずに書き込み可否を確認しながら処理します。
             完了マーカー <code>@SendGridPathUtility.MoreCompactionStatusFileName</code> が年月フォルダ直下に存在する場合は処理済みとして先に進みません。
         </small>
     </p>

--- a/SendgridParquetViewer/Components/Pages/MoreCompaction.razor
+++ b/SendgridParquetViewer/Components/Pages/MoreCompaction.razor
@@ -27,7 +27,7 @@
     </p>
     <p>
         <small>
-            出力ファイル名は <code>compaction&lt;yyyyMMddHH&gt;.parquet</code> で、フォルダをまたいでも一意になります。
+            出力ファイル名は <code>morecompaction&lt;yyyyMMddHH&gt;.parquet</code> で、通常 Compaction 出力と区別でき、フォルダをまたいでも一意になります。
             処理中断の耐性のためアップロード前に同名ファイルを削除してから書き込みます。
             完了マーカー <code>@SendGridPathUtility.MoreCompactionStatusFileName</code> が年月フォルダ直下に存在する場合は処理済みとして先に進みません。
         </small>

--- a/SendgridParquetViewer/Components/Pages/MoreCompaction.razor
+++ b/SendgridParquetViewer/Components/Pages/MoreCompaction.razor
@@ -415,7 +415,10 @@
         {
             return;
         }
-        await RunFoldersAsync(_scan.MultiFileFolders);
+        // _remainingFolders は RunFoldersAsync 中に成功行から除去される。
+        // 初回スキャン結果 (_scan.MultiFileFolders) を渡すと 個別実行で既に処理済みの
+        // フォルダまで再実行してしまうので、現時点での残フォルダのスナップショットを渡す。
+        await RunFoldersAsync([.. _remainingFolders]);
     }
 
     private async Task RunFoldersAsync(IReadOnlyList<MoreCompactionService.HourFolder> folders)

--- a/SendgridParquetViewer/Components/Pages/MoreCompaction.razor
+++ b/SendgridParquetViewer/Components/Pages/MoreCompaction.razor
@@ -12,7 +12,7 @@
 
 <PageTitle>追加コンパクション</PageTitle>
 
-<FluentCard class="main-card">
+<FluentCard class="main-card more-compaction-card">
     <FluentHeader>
         <FluentSpacer />
         <FluentLabel Typo="Typography.PageTitle">追加コンパクション</FluentLabel>
@@ -214,6 +214,15 @@
 </FluentCard>
 
 <style>
+    /* FluentCard はデフォルトで固定高さ/contain のため、FluentDatePicker のカレンダーポップアップが下側でクリップされる。
+       高さを中身に合わせて伸ばし、ポップアップは外側に overflow させる。 */
+    .more-compaction-card {
+        height: auto;
+        min-height: calc(100vh - 3rem);
+        overflow: visible;
+        contain: none;
+    }
+
     .more-compaction-table {
         border-collapse: collapse;
         width: 100%;

--- a/SendgridParquetViewer/Components/Pages/MoreCompaction.razor
+++ b/SendgridParquetViewer/Components/Pages/MoreCompaction.razor
@@ -351,8 +351,23 @@
                 }
             }
 
-            // 実行後に再スキャンして最新状態を反映する
+            // 実行後に再スキャンして最新状態を反映するが、実行ログは保持する
+            List<string> existingRunLog = [.. _runLog];
+            string? existingMessage = _message;
+            MessageIntent existingMessageIntent = _messageIntent;
+
             await OnScanClickedAsync();
+
+            _runLog.Clear();
+            _runLog.AddRange(existingRunLog);
+
+            if (string.IsNullOrEmpty(_message) && !string.IsNullOrEmpty(existingMessage))
+            {
+                _message = existingMessage;
+                _messageIntent = existingMessageIntent;
+            }
+
+            StateHasChanged();
         }
         finally
         {

--- a/SendgridParquetViewer/Components/Pages/MoreCompaction.razor
+++ b/SendgridParquetViewer/Components/Pages/MoreCompaction.razor
@@ -21,8 +21,9 @@
 
     <p>
         通常の Compaction 処理が途中で失敗すると、<code>v3compaction/yyyy/MM/dd/HH</code> フォルダに
-        複数の Parquet ファイルが残ることがあります。この画面では年月単位で対象フォルダを洗い出し、
-        1 フォルダ 1 Parquet ファイルへ統合します。
+        複数の Parquet ファイルが残ることがあります。この画面では対象フォルダを洗い出し、
+        1 フォルダ 1 Parquet ファイルへ統合します。年月モードでは月全体を、年月日モードではその日 1 日だけをスキャン対象とします
+        (年月日モードでは月単位の完了マーカーは書き込みません)。
     </p>
     <p>
         <small>
@@ -32,17 +33,26 @@
         </small>
     </p>
 
-    <FluentStack Orientation="Orientation.Horizontal" VerticalAlignment="VerticalAlignment.Center" Style="gap: 1em; flex-wrap: wrap;">
-        <FluentNumberField TValue="int" @bind-Value="_selectedYear" Label="年" Min="2000" Max="2999" Style="width: 8em;" />
-        <FluentNumberField TValue="int" @bind-Value="_selectedMonth" Label="月" Min="1" Max="12" Style="width: 8em;" />
-        <FluentButton Appearance="Appearance.Accent" OnClick="OnScanClickedAsync" Disabled="@(_isScanning || _isRunning)">
-            @(_isScanning ? "スキャン中..." : "スキャン")
-        </FluentButton>
+    <FluentStack Orientation="Orientation.Horizontal" VerticalAlignment="VerticalAlignment.Top" Style="gap: 1em; flex-wrap: wrap;">
+        <div style="min-width: 220px;">
+            <FluentDatePicker @bind-Value="_selectedDate" Label="対象日付" Style="width: 100%;" />
+            <FluentRadioGroup @bind-Value="_dateSelectionMode" Style="margin-top: 5px;">
+                <FluentRadio Value="@DateSelectionMode.YearMonth">年月のみ使用（日付は無視）</FluentRadio>
+                <FluentRadio Value="@DateSelectionMode.YearMonthDay">年月日すべて使用</FluentRadio>
+            </FluentRadioGroup>
+        </div>
+        <div style="margin-top: 25px;">
+            <FluentButton Appearance="Appearance.Accent" OnClick="OnScanClickedAsync" Disabled="@(_isScanning || _isRunning)">
+                @(_isScanning ? "スキャン中..." : "スキャン")
+            </FluentButton>
+        </div>
         @if (_maxSelectable is { } maxSel)
         {
-            <FluentLabel>
-                <small>選択可能な最新年月: @maxSel.Year / @($"{maxSel.Month:D2}")</small>
-            </FluentLabel>
+            <div style="margin-top: 30px;">
+                <FluentLabel>
+                    <small>選択可能な最新年月: @maxSel.Year / @($"{maxSel.Month:D2}")</small>
+                </FluentLabel>
+            </div>
         }
     </FluentStack>
 
@@ -55,9 +65,9 @@
                 {
                     <small>
                         スキャン中:
-                        @if (sp.CurrentDay is { } d)
+                        @if (sp.CurrentDay is { } d && _selectedDate is { } sd)
                         {
-                            @($"{_selectedYear}/{_selectedMonth:D2}/{d:D2}")
+                            @($"{sd.Year}/{sd.Month:D2}/{d:D2}")
                         }
                         else
                         {
@@ -97,9 +107,11 @@
     else if (_scanCompleted && _scan != null)
     {
         <FluentCard style="margin-top: 1em;">
-            <h3>スキャン結果: @_scan.Year / @($"{_scan.Month:D2}")</h3>
+            <h3>
+                スキャン結果: @_scan.Year / @($"{_scan.Month:D2}")@(_scanDay is { } sd ? $" / {sd:D2}" : string.Empty)
+            </h3>
             <p>
-                全 <strong>@_scan.TotalHourFolders</strong> 件の yyyy/MM/dd/HH フォルダを確認しました。<br />
+                全 <strong>@_scan.TotalHourFolders</strong> 件の @(_scanDay is null ? "yyyy/MM/dd/HH" : "yyyy/MM/dd/HH (当日)") フォルダを確認しました。<br />
                 Parquet が 2 つ以上あるフォルダ: <strong>@_scan.MultiFileFolders.Count</strong> 件
                 @if (_scan.MultiFileFolders.Count != _remainingFolders.Count)
                 {
@@ -111,14 +123,18 @@
             {
                 @if (_scan.TotalHourFolders == 0)
                 {
-                    <p>この年月に対象フォルダは存在しません。</p>
+                    <p>この @(_scanDay is null ? "年月" : "日付") に対象フォルダは存在しません。</p>
                 }
-                else
+                else if (_scanDay is null)
                 {
                     <p>すべてのフォルダが 1 parquet のみです。完了マーカーを書き込みます。</p>
                     <FluentButton Appearance="Appearance.Accent" OnClick="OnWriteStatusClickedAsync" Disabled="@_isRunning">
                         完了マーカーを書き込む
                     </FluentButton>
+                }
+                else
+                {
+                    <p>この日付のすべての hour フォルダが 1 parquet のみです。</p>
                 }
             }
             else
@@ -136,10 +152,17 @@
 
                 @if (_remainingFolders.Count == 0)
                 {
-                    <p>すべての対象フォルダの統合が完了しました。完了マーカーを書き込めます。</p>
-                    <FluentButton Appearance="Appearance.Accent" OnClick="OnWriteStatusClickedAsync" Disabled="@_isRunning">
-                        完了マーカーを書き込む
-                    </FluentButton>
+                    @if (_scanDay is null)
+                    {
+                        <p>すべての対象フォルダの統合が完了しました。完了マーカーを書き込めます。</p>
+                        <FluentButton Appearance="Appearance.Accent" OnClick="OnWriteStatusClickedAsync" Disabled="@_isRunning">
+                            完了マーカーを書き込む
+                        </FluentButton>
+                    }
+                    else
+                    {
+                        <p>この日付の対象フォルダはすべて統合が完了しました。</p>
+                    }
                 }
                 else
                 {
@@ -210,8 +233,14 @@
 </style>
 
 @code {
-    private int _selectedYear;
-    private int _selectedMonth;
+    public enum DateSelectionMode
+    {
+        YearMonth,
+        YearMonthDay
+    }
+
+    private DateSelectionMode _dateSelectionMode = DateSelectionMode.YearMonth;
+    private DateTime? _selectedDate; // FluentDatePicker に bind するときは nullable でなければならない
     private (int Year, int Month)? _maxSelectable;
 
     private bool _isScanning;
@@ -223,6 +252,7 @@
     private MoreCompactionService.DiskSpaceEstimate? _diskEstimate;
     private MoreCompactionService.ScanProgress? _scanProgress;
     private List<MoreCompactionService.HourFolder> _remainingFolders = [];
+    private int? _scanDay;
 
     private string _message = string.Empty;
     private MessageIntent _messageIntent = MessageIntent.Info;
@@ -235,8 +265,7 @@
         // 選択可能な最新年月 = 今月の 1 つ前
         DateTimeOffset previousMonth = nowJst.AddMonths(-1);
         _maxSelectable = (previousMonth.Year, previousMonth.Month);
-        _selectedYear = previousMonth.Year;
-        _selectedMonth = previousMonth.Month;
+        _selectedDate = new DateTime(previousMonth.Year, previousMonth.Month, 1);
     }
 
     private bool ValidateSelection()
@@ -246,14 +275,14 @@
             ShowMessage("選択可能年月の算出に失敗しました。", MessageIntent.Error);
             return false;
         }
-
-        int selected = _selectedYear * 100 + _selectedMonth;
-        int max = maxSel.Year * 100 + maxSel.Month;
-        if (_selectedMonth is < 1 or > 12)
+        if (_selectedDate is not { } date)
         {
-            ShowMessage("月は 1 から 12 の範囲で指定してください。", MessageIntent.Error);
+            ShowMessage("対象日付を選択してください。", MessageIntent.Error);
             return false;
         }
+
+        int selected = date.Year * 100 + date.Month;
+        int max = maxSel.Year * 100 + maxSel.Month;
         if (selected > max)
         {
             ShowMessage($"先月以前の年月のみ指定できます (最新: {maxSel.Year}/{maxSel.Month:D2})。", MessageIntent.Warning);
@@ -269,23 +298,32 @@
             return;
         }
 
+        DateTime date = _selectedDate!.Value;
+        int year = date.Year;
+        int month = date.Month;
+        int? day = _dateSelectionMode == DateSelectionMode.YearMonthDay ? date.Day : null;
+
         _status = null;
         _scan = null;
         _diskEstimate = null;
         _scanCompleted = false;
         _scanProgress = null;
         _remainingFolders = [];
+        _scanDay = day;
         _runLog.Clear();
         _message = string.Empty;
 
         _isScanning = true;
         try
         {
-            _status = await MoreCompactionService.GetStatusAsync(_selectedYear, _selectedMonth, _cts.Token);
-            if (_status != null)
+            if (day is null)
             {
-                ShowMessage("処理完了済みのためスキャンを実施しません。", MessageIntent.Info);
-                return;
+                _status = await MoreCompactionService.GetStatusAsync(year, month, _cts.Token);
+                if (_status != null)
+                {
+                    ShowMessage("処理完了済みのためスキャンを実施しません。", MessageIntent.Info);
+                    return;
+                }
             }
 
             var progress = new Progress<MoreCompactionService.ScanProgress>(p =>
@@ -293,7 +331,7 @@
                 _scanProgress = p;
                 StateHasChanged();
             });
-            MoreCompactionService.ScanResult scan = await MoreCompactionService.ScanAsync(_selectedYear, _selectedMonth, _cts.Token, progress);
+            MoreCompactionService.ScanResult scan = await MoreCompactionService.ScanAsync(year, month, _cts.Token, progress, day);
             _scan = scan;
             _scanCompleted = true;
             _remainingFolders = [.. scan.MultiFileFolders];
@@ -301,11 +339,15 @@
 
             if (scan.TotalHourFolders == 0)
             {
-                ShowMessage("この年月に対象フォルダは存在しません。", MessageIntent.Info);
+                ShowMessage(day is null
+                    ? "この年月に対象フォルダは存在しません。"
+                    : "この日付に対象フォルダは存在しません。", MessageIntent.Info);
             }
             else if (scan.MultiFileFolders.Count == 0)
             {
-                ShowMessage("すべてのフォルダが 1 parquet のみです。完了マーカーを書き込めます。", MessageIntent.Success);
+                ShowMessage(day is null
+                    ? "すべてのフォルダが 1 parquet のみです。完了マーカーを書き込めます。"
+                    : "この日付のすべての hour フォルダが 1 parquet のみです。", MessageIntent.Success);
             }
             else
             {
@@ -318,7 +360,7 @@
         }
         catch (Exception ex)
         {
-            Logger.ZLogError(ex, $"Scan failed {_selectedYear}/{_selectedMonth}");
+            Logger.ZLogError(ex, $"Scan failed {year}/{month}{(day is { } d ? $"/{d:D2}" : string.Empty)}");
             ShowMessage("スキャンに失敗しました。", MessageIntent.Error);
         }
         finally

--- a/SendgridParquetViewer/Models/AppJsonSerializerContext.cs
+++ b/SendgridParquetViewer/Models/AppJsonSerializerContext.cs
@@ -8,6 +8,7 @@ namespace SendgridParquetViewer.Models;
 [JsonSerializable(typeof(LockInfo[]))]
 [JsonSerializable(typeof(SearchCondition))]
 [JsonSerializable(typeof(SearchCondition[]))]
+[JsonSerializable(typeof(MoreCompactionStatus))]
 [JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Default,
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     WriteIndented = true // 人間が読むこともあるのでインデントする

--- a/SendgridParquetViewer/Models/AzureAdIdentityOptions.cs
+++ b/SendgridParquetViewer/Models/AzureAdIdentityOptions.cs
@@ -1,4 +1,4 @@
-namespace SendgridParquetViewer.Models;
+﻿namespace SendgridParquetViewer.Models;
 
 /// <summary>
 /// AzureAd 構成のうち、Slack 通知にアプリケーション識別情報として載せたい部分だけを取り出すための Options。

--- a/SendgridParquetViewer/Models/MoreCompactionStatus.cs
+++ b/SendgridParquetViewer/Models/MoreCompactionStatus.cs
@@ -1,0 +1,26 @@
+﻿using System.Text.Json.Serialization;
+
+namespace SendgridParquetViewer.Models;
+
+/// <summary>
+/// 追加コンパクション (MoreCompaction) の完了マーカー。
+/// この JSON が対象年月に存在すれば、当該年月の全 yyyy/MM/dd/HH フォルダに
+/// Parquet ファイルが 1 つしか存在しないことが保証される。
+/// </summary>
+public class MoreCompactionStatus
+{
+    [JsonPropertyName("year")]
+    public int Year { get; init; }
+
+    [JsonPropertyName("month")]
+    public int Month { get; init; }
+
+    [JsonPropertyName("completedAt")]
+    public DateTimeOffset CompletedAt { get; init; }
+
+    /// <summary>
+    /// 確認した yyyy/MM/dd/HH フォルダの数。
+    /// </summary>
+    [JsonPropertyName("verifiedHourFolders")]
+    public int VerifiedHourFolders { get; init; }
+}

--- a/SendgridParquetViewer/Models/SlackNotifierOptions.cs
+++ b/SendgridParquetViewer/Models/SlackNotifierOptions.cs
@@ -1,4 +1,4 @@
-namespace SendgridParquetViewer.Models;
+﻿namespace SendgridParquetViewer.Models;
 
 public class SlackNotifierOptions
 {

--- a/SendgridParquetViewer/Program.cs
+++ b/SendgridParquetViewer/Program.cs
@@ -156,6 +156,9 @@ builder.Services.AddSingleton<CompactionHealthCheck>();
 builder.Services.AddSingleton<CompactionService>(); // 1プロセスあたり同時実行は1つだけにする
 builder.Services.AddHostedService<CompactionStartupHostedService>(); // 起動時にコンパクションを開始するホストサービス
 
+// Add MoreCompaction service (手動で画面から実行する 追加コンパクション)
+builder.Services.AddSingleton<MoreCompactionService>();
+
 // Add health checks
 builder.Services.AddHealthChecks();
 

--- a/SendgridParquetViewer/Services/CompactionHealthCheck.cs
+++ b/SendgridParquetViewer/Services/CompactionHealthCheck.cs
@@ -1,4 +1,4 @@
-using SendgridParquet.Shared;
+﻿using SendgridParquet.Shared;
 
 using ZLogger;
 

--- a/SendgridParquetViewer/Services/CompactionService.cs
+++ b/SendgridParquetViewer/Services/CompactionService.cs
@@ -416,10 +416,7 @@ public class CompactionService(
     {
         logger.ZLogInformation($"List files for {targetDate} at path {pathPrefix}");
 
-        var allObjects = await s3StorageService.ListFilesAsync(pathPrefix, token);
-        var targetParquetFiles = allObjects
-            .Where(key => key.EndsWith(SendGridPathUtility.ParquetFileExtension, StringComparison.OrdinalIgnoreCase))
-            .ToArray();
+        var targetParquetFiles = await s3StorageService.ListParquetFilesAsync(pathPrefix, token);
 
         if (!targetParquetFiles.Any())
         {

--- a/SendgridParquetViewer/Services/MoreCompactionService.cs
+++ b/SendgridParquetViewer/Services/MoreCompactionService.cs
@@ -209,11 +209,16 @@ public class MoreCompactionService(
     /// <summary>
     /// 指定フォルダを 1 ファイルへ統合する。出力名は folder-unique な
     /// morecompaction{yyyy}{MM}{dd}{HH}.parquet (<see cref="SendGridPathUtility.GetMoreCompactionFileName"/>)。
-    /// 手順:
-    ///   1. 既存の出力キー (同一キー) があれば削除 (前回アップロード中断への対処)
-    ///   2. フォルダ内 Parquet をストリーミングで読みながら 一時ファイルに 1 つの Parquet を作成
-    ///   3. 一時ファイルを S3 へアップロード
-    ///   4. 検証成功後に 元ファイル (出力キー以外) を削除
+    /// 再実行で冪等になるよう、既存の出力キーがあれば検証のみ行う:
+    ///   A. 出力キーが既に存在する (前回アップロード完了後に 元ソース削除の途中で中断したケース):
+    ///      検証に成功したら 残ソースの削除だけを実施する。
+    ///      (残ソースは欠けている可能性があるため再マージしない。再マージで outputKey を
+    ///       消して サブセットで書き直すと データ損失になる。)
+    ///   B. 出力キーが無い (初回または アップロード前に中断したケース):
+    ///      1. フォルダ内 Parquet をストリーミングで読みながら 一時ファイルに 1 つの Parquet を作成
+    ///      2. 一時ファイルを S3 へアップロード
+    ///      3. 検証
+    ///      4. 元ファイル削除
     /// </summary>
     public async Task<MoreCompactionFolderResult> ExecuteFolderAsync(HourFolder folder, CancellationToken ct)
     {
@@ -228,24 +233,48 @@ public class MoreCompactionService(
             return new MoreCompactionFolderResult(folder, Skipped: true, TotalEvents: 0, DeletedFiles: 0);
         }
 
-        // (1) 既存の出力ファイル (同一キー) を削除。中断後の残骸を確実に消す。
-        await s3StorageService.DeleteObjectAsync(outputKey, ct);
-
-        IReadOnlyList<S3ObjectEntry> readTargets = sources
+        bool existingOutputPresent = sources.Any(e => string.Equals(e.Key, outputKey, StringComparison.Ordinal));
+        IReadOnlyList<S3ObjectEntry> leftoverSources = sources
             .Where(e => !string.Equals(e.Key, outputKey, StringComparison.Ordinal))
             .ToArray();
 
-        if (readTargets.Count == 0)
+        // (A) 前回実行がアップロード成功後に元ソース削除の途中で中断したケース。
+        // outputKey が読めることを確認した上で、残ソースの削除のみ行う。
+        // ここで outputKey を削除 → 残ソースから再マージ、としてしまうと、
+        // 元ソースが部分削除されている場合に完成済み merged データを失う恐れがある。
+        // outputKey の検証で例外が出た場合はそのまま throw して 人手の確認を促す
+        // (破損している outputKey を勝手に削除して 中身未知のソースから書き直すのは危険)。
+        if (existingOutputPresent)
         {
-            logger.ZLogInformation($"MoreCompaction no readable sources after excluding {outputKey}: {folder.Prefix}");
+            logger.ZLogInformation($"MoreCompaction existing output found; verify and cleanup only: {outputKey}");
+            await VerifyUploadedParquetAsync(outputKey, ct);
+
+            int cleaned = 0;
+            foreach (S3ObjectEntry src in leftoverSources)
+            {
+                ct.ThrowIfCancellationRequested();
+                if (await s3StorageService.DeleteObjectAsync(src.Key, ct))
+                {
+                    cleaned++;
+                }
+            }
+            logger.ZLogInformation($"MoreCompaction resumed cleanup: {folder.Prefix} deleted={cleaned}");
+            return new MoreCompactionFolderResult(folder, Skipped: false, TotalEvents: 0, DeletedFiles: cleaned);
+        }
+
+        // (B) 通常ケース: outputKey が無いので マージして新規作成する。
+
+        if (leftoverSources.Count == 0)
+        {
+            logger.ZLogInformation($"MoreCompaction no readable sources: {folder.Prefix}");
             return new MoreCompactionFolderResult(folder, Skipped: true, TotalEvents: 0, DeletedFiles: 0);
         }
 
-        // (2) ストリーミングで 1 つの Parquet を一時ファイルへ書き出す。
+        // (1) ストリーミングで 1 つの Parquet を一時ファイルへ書き出す。
         long totalEvents = 0;
         await using FileStream outputStream = DisposableTempFile.Open(nameof(MoreCompactionService) + "-output");
         bool hasData = await parquetService.ConvertToParquetStreamingAsync(
-            EnumerateSourceEventsAsync(readTargets, count => Interlocked.Add(ref totalEvents, count), ct),
+            EnumerateSourceEventsAsync(leftoverSources, count => Interlocked.Add(ref totalEvents, count), ct),
             outputStream,
             rowGroupSize: RowGroupSize,
             token: ct);
@@ -256,7 +285,7 @@ public class MoreCompactionService(
             return new MoreCompactionFolderResult(folder, Skipped: true, TotalEvents: 0, DeletedFiles: 0);
         }
 
-        // (3) S3 へアップロード。
+        // (2) S3 へアップロード。PUT は atomic なので 既存が無い前提のこの分岐では上書き競合は起きない。
         outputStream.Seek(0, SeekOrigin.Begin);
         bool uploaded = await s3StorageService.PutObjectAsync(outputStream, outputKey, ct);
         if (!uploaded)
@@ -264,18 +293,14 @@ public class MoreCompactionService(
             throw new InvalidOperationException($"Failed to upload merged parquet: {outputKey}");
         }
 
-        // アップロード後 Parquet として読めるか検証。
+        // (3) アップロード後 Parquet として読めるか検証。
         await VerifyUploadedParquetAsync(outputKey, ct);
 
-        // (4) 元ファイル (出力キー自身を除く) を削除。
+        // (4) 元ファイルを削除。outputKey は leftoverSources に含まれない (上で除外済み) ので 誤削除されない。
         int deleted = 0;
-        foreach (S3ObjectEntry src in readTargets)
+        foreach (S3ObjectEntry src in leftoverSources)
         {
             ct.ThrowIfCancellationRequested();
-            if (string.Equals(src.Key, outputKey, StringComparison.Ordinal))
-            {
-                continue;
-            }
             if (await s3StorageService.DeleteObjectAsync(src.Key, ct))
             {
                 deleted++;

--- a/SendgridParquetViewer/Services/MoreCompactionService.cs
+++ b/SendgridParquetViewer/Services/MoreCompactionService.cs
@@ -207,12 +207,13 @@ public class MoreCompactionService(
     }
 
     /// <summary>
-    /// 指定フォルダを 1 ファイルへ統合する。
+    /// 指定フォルダを 1 ファイルへ統合する。出力名は folder-unique な
+    /// morecompaction{yyyy}{MM}{dd}{HH}.parquet (<see cref="SendGridPathUtility.GetMoreCompactionFileName"/>)。
     /// 手順:
-    ///   1. 既存の morecompaction.parquet があれば削除 (前回アップロード中断への対処)
+    ///   1. 既存の出力キー (同一キー) があれば削除 (前回アップロード中断への対処)
     ///   2. フォルダ内 Parquet をストリーミングで読みながら 一時ファイルに 1 つの Parquet を作成
     ///   3. 一時ファイルを S3 へアップロード
-    ///   4. 検証成功後に 元ファイル (morecompaction.parquet 以外) を削除
+    ///   4. 検証成功後に 元ファイル (出力キー以外) を削除
     /// </summary>
     public async Task<MoreCompactionFolderResult> ExecuteFolderAsync(HourFolder folder, CancellationToken ct)
     {

--- a/SendgridParquetViewer/Services/MoreCompactionService.cs
+++ b/SendgridParquetViewer/Services/MoreCompactionService.cs
@@ -277,7 +277,9 @@ public class MoreCompactionService(
         // 実行時点でも outputKey の存在を S3 に問い合わせ直して保守的に確認する。
         // (スキャン結果だけに依存すると TOCTOU で 完成済み merged を上書きし、
         // 元ソースが部分削除されているタイミングだと データ欠損 parquet で塗り替える恐れがある。)
-        bool existingOutputLive = await s3StorageService.AnyFileExistsAsync(outputKey, ct);
+        // AnyFileExistsAsync は prefix 末尾に '/' を補って ListObjectsV2 する実装で
+        // 完全キーの存在確認には使えないため、HEAD で問い合わせる ObjectExistsAsync を使う。
+        bool existingOutputLive = await s3StorageService.ObjectExistsAsync(outputKey, ct);
         bool existingOutputPresent = existingOutputInScan || existingOutputLive;
 
         // (A) 前回実行がアップロード成功後に元ソース削除の途中で中断したケース、または

--- a/SendgridParquetViewer/Services/MoreCompactionService.cs
+++ b/SendgridParquetViewer/Services/MoreCompactionService.cs
@@ -120,18 +120,14 @@ public class MoreCompactionService(
 
         progress?.Report(new ScanProgress(0, 0, null, 0));
 
-        IReadOnlyCollection<S3ObjectEntry> entries = await s3StorageService.ListFilesWithSizeAsync(prefix, ct);
+        IReadOnlyCollection<S3ObjectEntry> entries = await s3StorageService.ListParquetFilesWithSizeAsync(prefix, ct);
         ct.ThrowIfCancellationRequested();
 
-        // (yyyy, MM, dd, HH) にグループ化。キー分解に失敗したもの (例: morecompaction.json や
-        // 不正なパス) はスキップ。
+        // (yyyy, MM, dd, HH) にグループ化。キー分解に失敗したもの (不正パスなど) はスキップ。
+        // 拡張子フィルタは ListParquetFilesWithSizeAsync 側で担保される。
         var grouped = new Dictionary<(int Year, int Month, int Day, int Hour), List<S3ObjectEntry>>();
         foreach (S3ObjectEntry entry in entries)
         {
-            if (!entry.Key.EndsWith(SendGridPathUtility.ParquetFileExtension, StringComparison.OrdinalIgnoreCase))
-            {
-                continue;
-            }
             if (!TryParseCompactionKey(entry.Key, out int y, out int m, out int d, out int h))
             {
                 continue;

--- a/SendgridParquetViewer/Services/MoreCompactionService.cs
+++ b/SendgridParquetViewer/Services/MoreCompactionService.cs
@@ -1,0 +1,321 @@
+﻿using System.Runtime.CompilerServices;
+using System.Text.Json;
+
+using Parquet;
+
+using SendgridParquet.Shared;
+
+using SendgridParquetViewer.Models;
+
+using ZLogger;
+
+namespace SendgridParquetViewer.Services;
+
+/// <summary>
+/// 追加コンパクション (MoreCompaction) の実行サービス。
+///
+/// 通常の Compaction が途中で失敗すると v3compaction/yyyy/MM/dd/HH 直下に
+/// 複数の parquet ファイルが残ることがあるため、指定した年月について
+/// 1 時間フォルダ あたり 1 ファイルへ統合する。
+/// 自動実行はせず 画面からの明示指示で 年月単位のスキャン / フォルダ単位の実行を行う。
+/// </summary>
+public class MoreCompactionService(
+    ILogger<MoreCompactionService> logger,
+    S3StorageService s3StorageService,
+    ParquetService parquetService,
+    TimeProvider timeProvider
+)
+{
+    /// <summary>
+    /// Compaction と同じ RowGroup サイズ。
+    /// メモリ使用量を抑えるためストリーミングで書き込む。
+    /// </summary>
+    private const int RowGroupSize = 60_000;
+
+    public sealed record HourFolder(
+        int Year,
+        int Month,
+        int Day,
+        int Hour,
+        string Prefix,
+        IReadOnlyList<S3ObjectEntry> ParquetFiles)
+    {
+        public long TotalBytes => ParquetFiles.Sum(f => f.Size);
+    }
+
+    public sealed record ScanResult(
+        int Year,
+        int Month,
+        IReadOnlyList<HourFolder> AllHourFolders,
+        IReadOnlyList<HourFolder> MultiFileFolders)
+    {
+        public int TotalHourFolders => AllHourFolders.Count;
+
+        /// <summary>
+        /// 逐次実行時に一時的に必要となる最大ディスク量。
+        /// MoreCompaction は 1 フォルダずつ処理するため、最大サイズのフォルダ 1 つぶん。
+        /// </summary>
+        public long MaxTempBytesPerFolder =>
+            MultiFileFolders.Count == 0 ? 0L : MultiFileFolders.Max(f => f.TotalBytes);
+    }
+
+    public sealed record DiskSpaceEstimate(
+        string TempPath,
+        long RequiredBytes,
+        long AvailableFreeBytes,
+        bool IsSufficient);
+
+    /// <summary>
+    /// 年月の完了マーカーを取得する。存在しない場合は null を返す。
+    /// </summary>
+    public async Task<MoreCompactionStatus?> GetStatusAsync(int year, int month, CancellationToken ct)
+    {
+        string key = SendGridPathUtility.GetS3MoreCompactionStatusKey(year, month);
+        try
+        {
+            byte[] content = await s3StorageService.GetObjectAsByteArrayAsync(key, ct);
+            if (content.Length == 0)
+            {
+                return null;
+            }
+            return JsonSerializer.Deserialize(content, AppJsonSerializerContext.Default.MoreCompactionStatus);
+        }
+        catch (Exception ex)
+        {
+            logger.ZLogWarning(ex, $"Unable to read more-compaction status from {key}");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// 指定年月の v3compaction/yyyy/MM/dd/HH フォルダを全走査し、
+    /// Parquet ファイルが 2 つ以上あるフォルダを洗い出す。
+    /// </summary>
+    public async Task<ScanResult> ScanAsync(int year, int month, CancellationToken ct)
+    {
+        var monthPrefix = SendGridPathUtility.GetS3CompactionPrefix(year, month, null, null);
+        IEnumerable<string> dayDirs = await s3StorageService.ListDirectoriesAsync(monthPrefix, ct);
+
+        var allFolders = new List<HourFolder>();
+        var multi = new List<HourFolder>();
+
+        foreach (int day in dayDirs.Select(d => int.TryParse(d, out int v) ? v : 0)
+                     .Where(v => v > 0)
+                     .OrderBy(v => v))
+        {
+            ct.ThrowIfCancellationRequested();
+            var dayPrefix = SendGridPathUtility.GetS3CompactionPrefix(year, month, day, null);
+            IEnumerable<string> hourDirs = await s3StorageService.ListDirectoriesAsync(dayPrefix, ct);
+
+            foreach (int hour in hourDirs.Select(h => int.TryParse(h, out int v) ? v : -1)
+                         .Where(v => v >= 0)
+                         .OrderBy(v => v))
+            {
+                ct.ThrowIfCancellationRequested();
+                var hourPrefix = SendGridPathUtility.GetS3CompactionPrefix(year, month, day, hour);
+                IReadOnlyCollection<S3ObjectEntry> entries = await s3StorageService.ListFilesWithSizeAsync(hourPrefix, ct);
+                var parquetFiles = entries
+                    .Where(e => e.Key.EndsWith(SendGridPathUtility.ParquetFileExtension, StringComparison.OrdinalIgnoreCase))
+                    .OrderBy(e => e.Key, StringComparer.Ordinal)
+                    .ToArray();
+
+                var folder = new HourFolder(year, month, day, hour, hourPrefix, parquetFiles);
+                allFolders.Add(folder);
+                if (parquetFiles.Length >= 2)
+                {
+                    multi.Add(folder);
+                }
+            }
+        }
+
+        return new ScanResult(year, month, allFolders, multi);
+    }
+
+    /// <summary>
+    /// 年月単位の完了マーカーを保存する。
+    /// 全フォルダが 1 parquet のみの場合に呼ぶ。
+    /// </summary>
+    public async Task<MoreCompactionStatus> WriteStatusAsync(int year, int month, int verifiedHourFolders, CancellationToken ct)
+    {
+        var status = new MoreCompactionStatus
+        {
+            Year = year,
+            Month = month,
+            CompletedAt = timeProvider.GetUtcNow(),
+            VerifiedHourFolders = verifiedHourFolders,
+        };
+        await using var ms = new MemoryStream();
+        await JsonSerializer.SerializeAsync(ms, status, AppJsonSerializerContext.Default.MoreCompactionStatus, ct);
+        ms.Seek(0, SeekOrigin.Begin);
+        string key = SendGridPathUtility.GetS3MoreCompactionStatusKey(year, month);
+        await s3StorageService.PutObjectAsync(ms, key, ct);
+        logger.ZLogInformation($"MoreCompaction status written: {key}");
+        return status;
+    }
+
+    /// <summary>
+    /// 一時フォルダの空き容量が 指定フォルダ処理時の想定最大ディスク消費量を満たすか見積もる。
+    /// </summary>
+    public static DiskSpaceEstimate EstimateDiskSpace(long requiredBytes)
+    {
+        string tempPath = Path.GetTempPath();
+        long available = 0L;
+        try
+        {
+            string driveRoot = Path.GetPathRoot(tempPath) ?? tempPath;
+            var driveInfo = new DriveInfo(driveRoot);
+            if (driveInfo.IsReady)
+            {
+                available = driveInfo.AvailableFreeSpace;
+            }
+        }
+        catch
+        {
+            // DriveInfo 取得失敗時は available=0 とし、不足扱いで警告する
+        }
+
+        bool sufficient = available > 0 && available >= requiredBytes;
+        return new DiskSpaceEstimate(tempPath, requiredBytes, available, sufficient);
+    }
+
+    /// <summary>
+    /// 指定フォルダを 1 ファイルへ統合する。
+    /// 手順:
+    ///   1. 既存の morecompaction.parquet があれば削除 (前回アップロード中断への対処)
+    ///   2. フォルダ内 Parquet をストリーミングで読みながら 一時ファイルに 1 つの Parquet を作成
+    ///   3. 一時ファイルを S3 へアップロード
+    ///   4. 検証成功後に 元ファイル (morecompaction.parquet 以外) を削除
+    /// </summary>
+    public async Task<MoreCompactionFolderResult> ExecuteFolderAsync(HourFolder folder, CancellationToken ct)
+    {
+        logger.ZLogInformation($"MoreCompaction start: {folder.Prefix} files={folder.ParquetFiles.Count} totalBytes={folder.TotalBytes}");
+
+        string outputKey = SendGridPathUtility.GetS3MoreCompactionParquetKey(folder.Year, folder.Month, folder.Day, folder.Hour);
+
+        IReadOnlyList<S3ObjectEntry> sources = folder.ParquetFiles;
+        if (sources.Count <= 1)
+        {
+            logger.ZLogInformation($"MoreCompaction skip (already <=1 file): {folder.Prefix}");
+            return new MoreCompactionFolderResult(folder, Skipped: true, TotalEvents: 0, DeletedFiles: 0);
+        }
+
+        // (1) 既存の morecompaction.parquet を削除。中断後の残骸を確実に消す。
+        await s3StorageService.DeleteObjectAsync(outputKey, ct);
+
+        IReadOnlyList<S3ObjectEntry> readTargets = sources
+            .Where(e => !e.Key.EndsWith("/" + SendGridPathUtility.MoreCompactionFileName, StringComparison.Ordinal))
+            .ToArray();
+
+        if (readTargets.Count == 0)
+        {
+            logger.ZLogInformation($"MoreCompaction no readable sources after excluding {SendGridPathUtility.MoreCompactionFileName}: {folder.Prefix}");
+            return new MoreCompactionFolderResult(folder, Skipped: true, TotalEvents: 0, DeletedFiles: 0);
+        }
+
+        // (2) ストリーミングで 1 つの Parquet を一時ファイルへ書き出す。
+        long totalEvents = 0;
+        await using FileStream outputStream = DisposableTempFile.Open(nameof(MoreCompactionService) + "-output");
+        bool hasData = await parquetService.ConvertToParquetStreamingAsync(
+            EnumerateSourceEventsAsync(readTargets, count => Interlocked.Add(ref totalEvents, count), ct),
+            outputStream,
+            rowGroupSize: RowGroupSize,
+            token: ct);
+
+        if (!hasData)
+        {
+            logger.ZLogWarning($"MoreCompaction produced no events: {folder.Prefix}");
+            return new MoreCompactionFolderResult(folder, Skipped: true, TotalEvents: 0, DeletedFiles: 0);
+        }
+
+        // (3) S3 へアップロード。
+        outputStream.Seek(0, SeekOrigin.Begin);
+        bool uploaded = await s3StorageService.PutObjectAsync(outputStream, outputKey, ct);
+        if (!uploaded)
+        {
+            throw new InvalidOperationException($"Failed to upload merged parquet: {outputKey}");
+        }
+
+        // アップロード後 Parquet として読めるか検証。
+        await VerifyUploadedParquetAsync(outputKey, ct);
+
+        // (4) 元ファイル (出力キー自身を除く) を削除。
+        int deleted = 0;
+        foreach (S3ObjectEntry src in readTargets)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (string.Equals(src.Key, outputKey, StringComparison.Ordinal))
+            {
+                continue;
+            }
+            if (await s3StorageService.DeleteObjectAsync(src.Key, ct))
+            {
+                deleted++;
+            }
+        }
+
+        logger.ZLogInformation($"MoreCompaction done: {folder.Prefix} events={totalEvents} deleted={deleted}");
+        return new MoreCompactionFolderResult(folder, Skipped: false, TotalEvents: totalEvents, DeletedFiles: deleted);
+    }
+
+    private async IAsyncEnumerable<SendGridEvent> EnumerateSourceEventsAsync(
+        IReadOnlyList<S3ObjectEntry> sources,
+        Action<long> addedCount,
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        foreach (S3ObjectEntry entry in sources)
+        {
+            ct.ThrowIfCancellationRequested();
+            logger.ZLogInformation($"MoreCompaction reading {entry.Key} ({entry.Size} bytes)");
+
+            // Parquet 読み込みにはシーク可能なストリームが必要なため 一時ファイルに落としてから読む。
+            await using FileStream tempStream = DisposableTempFile.Open(nameof(MoreCompactionService) + "-src");
+            using (HttpResponseMessage response = await s3StorageService.GetObjectAsync(entry.Key, ct))
+            {
+                if (!response.IsSuccessStatusCode)
+                {
+                    logger.ZLogWarning($"MoreCompaction failed to download {entry.Key} status={response.StatusCode}");
+                    continue;
+                }
+                await using Stream body = await response.Content.ReadAsStreamAsync(ct);
+                await body.CopyToAsync(tempStream, DisposableTempFile.BufferSize, ct);
+            }
+            tempStream.Seek(0, SeekOrigin.Begin);
+
+            using ParquetReader reader = await ParquetReader.CreateAsync(tempStream, cancellationToken: ct);
+            for (int rg = 0; rg < reader.RowGroupCount; rg++)
+            {
+                ct.ThrowIfCancellationRequested();
+                using ParquetRowGroupReader rowGroupReader = reader.OpenRowGroupReader(rg);
+                long rowsInGroup = 0;
+                await foreach (SendGridEvent ev in parquetService.ReadRowGroupEventsAsync(rowGroupReader, reader, ct))
+                {
+                    rowsInGroup++;
+                    yield return ev;
+                }
+                addedCount(rowsInGroup);
+            }
+        }
+    }
+
+    private async Task VerifyUploadedParquetAsync(string key, CancellationToken ct)
+    {
+        using HttpResponseMessage response = await s3StorageService.GetObjectAsync(key, ct);
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException($"Verification failed: cannot fetch uploaded parquet {key} status={response.StatusCode}");
+        }
+
+        await using Stream body = await response.Content.ReadAsStreamAsync(ct);
+        await using FileStream verifyStream = DisposableTempFile.Open(nameof(MoreCompactionService) + "-verify");
+        await body.CopyToAsync(verifyStream, DisposableTempFile.BufferSize, ct);
+        verifyStream.Seek(0, SeekOrigin.Begin);
+        using ParquetReader reader = await ParquetReader.CreateAsync(verifyStream, cancellationToken: ct);
+        logger.ZLogInformation($"MoreCompaction verified: {key} rowGroups={reader.RowGroupCount}");
+    }
+}
+
+public sealed record MoreCompactionFolderResult(
+    MoreCompactionService.HourFolder Folder,
+    bool Skipped,
+    long TotalEvents,
+    int DeletedFiles);

--- a/SendgridParquetViewer/Services/MoreCompactionService.cs
+++ b/SendgridParquetViewer/Services/MoreCompactionService.cs
@@ -331,12 +331,23 @@ public class MoreCompactionService(
             return new MoreCompactionFolderResult(folder, Skipped: true, TotalEvents: 0, DeletedFiles: 0);
         }
 
-        // (2) S3 へアップロード。PUT は atomic なので 既存が無い前提のこの分岐では上書き競合は起きない。
+        // (2) S3 へアップロード。
+        // 注意: S3 PUT の atomicity は「部分書き込みが他者から見えない」保証で、上書き競合は防がない。
+        // live check (ObjectExistsAsync) 〜 PUT の間に別実行が同じ outputKey を先に書いているケースに
+        // 備えて、If-None-Match: * 付きの条件付き PUT で上書きを防ぐ。
         outputStream.Seek(0, SeekOrigin.Begin);
-        bool uploaded = await s3StorageService.PutObjectAsync(outputStream, outputKey, ct);
-        if (!uploaded)
+        S3ConditionalPutResult putResult = await s3StorageService.PutObjectIfNoneMatchAsync(outputKey, outputStream, ct);
+        switch (putResult)
         {
-            throw new InvalidOperationException($"Failed to upload merged parquet: {outputKey}");
+            case S3ConditionalPutResult.Uploaded:
+                break;
+            case S3ConditionalPutResult.PreconditionFailed:
+                // 別実行が先に outputKey を作成した。再スキャン → 再実行で A 分岐 (verify + cleanup) が引かれる。
+                throw new InvalidOperationException(
+                    $"Conditional PUT failed (concurrent writer created {outputKey}); re-run to enter verify+cleanup path.");
+            case S3ConditionalPutResult.Failed:
+            default:
+                throw new InvalidOperationException($"Failed to upload merged parquet: {outputKey}");
         }
 
         // (3) アップロード後 Parquet として読めるか検証。

--- a/SendgridParquetViewer/Services/MoreCompactionService.cs
+++ b/SendgridParquetViewer/Services/MoreCompactionService.cs
@@ -219,16 +219,16 @@ public class MoreCompactionService(
             return new MoreCompactionFolderResult(folder, Skipped: true, TotalEvents: 0, DeletedFiles: 0);
         }
 
-        // (1) 既存の morecompaction.parquet を削除。中断後の残骸を確実に消す。
+        // (1) 既存の出力ファイル (同一キー) を削除。中断後の残骸を確実に消す。
         await s3StorageService.DeleteObjectAsync(outputKey, ct);
 
         IReadOnlyList<S3ObjectEntry> readTargets = sources
-            .Where(e => !e.Key.EndsWith("/" + SendGridPathUtility.MoreCompactionFileName, StringComparison.Ordinal))
+            .Where(e => !string.Equals(e.Key, outputKey, StringComparison.Ordinal))
             .ToArray();
 
         if (readTargets.Count == 0)
         {
-            logger.ZLogInformation($"MoreCompaction no readable sources after excluding {SendGridPathUtility.MoreCompactionFileName}: {folder.Prefix}");
+            logger.ZLogInformation($"MoreCompaction no readable sources after excluding {outputKey}: {folder.Prefix}");
             return new MoreCompactionFolderResult(folder, Skipped: true, TotalEvents: 0, DeletedFiles: 0);
         }
 

--- a/SendgridParquetViewer/Services/MoreCompactionService.cs
+++ b/SendgridParquetViewer/Services/MoreCompactionService.cs
@@ -97,6 +97,8 @@ public class MoreCompactionService(
             }
             return JsonSerializer.Deserialize(content, AppJsonSerializerContext.Default.MoreCompactionStatus);
         }
+        // キャンセルは呼び出し元に伝搬させる (不要な警告ログも出さない)。
+        catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
         catch (Exception ex)
         {
             logger.ZLogWarning(ex, $"Unable to read more-compaction status from {key}");

--- a/SendgridParquetViewer/Services/MoreCompactionService.cs
+++ b/SendgridParquetViewer/Services/MoreCompactionService.cs
@@ -274,7 +274,8 @@ public class MoreCompactionService(
                 if (!response.IsSuccessStatusCode)
                 {
                     logger.ZLogWarning($"MoreCompaction failed to download {entry.Key} status={response.StatusCode}");
-                    continue;
+                    throw new InvalidOperationException(
+                        $"MoreCompaction cannot continue because source download failed for {entry.Key} status={response.StatusCode}");
                 }
                 await using Stream body = await response.Content.ReadAsStreamAsync(ct);
                 await body.CopyToAsync(tempStream, DisposableTempFile.BufferSize, ct);

--- a/SendgridParquetViewer/Services/MoreCompactionService.cs
+++ b/SendgridParquetViewer/Services/MoreCompactionService.cs
@@ -94,18 +94,26 @@ public class MoreCompactionService(
     }
 
     /// <summary>
-    /// 指定年月の v3compaction/yyyy/MM/dd/HH フォルダを全走査し、
+    /// 指定年月 (または 年月日) の v3compaction/yyyy/MM/dd/HH フォルダを走査し、
     /// Parquet ファイルが 2 つ以上あるフォルダを洗い出す。
+    /// day が指定された場合はその 1 日だけが対象。
     /// </summary>
-    public async Task<ScanResult> ScanAsync(int year, int month, CancellationToken ct, IProgress<ScanProgress>? progress = null)
+    public async Task<ScanResult> ScanAsync(int year, int month, CancellationToken ct, IProgress<ScanProgress>? progress = null, int? day = null)
     {
-        var monthPrefix = SendGridPathUtility.GetS3CompactionPrefix(year, month, null, null);
-        IEnumerable<string> dayDirs = await s3StorageService.ListDirectoriesAsync(monthPrefix, ct);
-
-        int[] days = dayDirs.Select(d => int.TryParse(d, out int v) ? v : 0)
-            .Where(v => v > 0)
-            .OrderBy(v => v)
-            .ToArray();
+        int[] days;
+        if (day is { } d)
+        {
+            days = [d];
+        }
+        else
+        {
+            var monthPrefix = SendGridPathUtility.GetS3CompactionPrefix(year, month, null, null);
+            IEnumerable<string> dayDirs = await s3StorageService.ListDirectoriesAsync(monthPrefix, ct);
+            days = dayDirs.Select(x => int.TryParse(x, out int v) ? v : 0)
+                .Where(v => v > 0)
+                .OrderBy(v => v)
+                .ToArray();
+        }
 
         var allFolders = new List<HourFolder>();
         var multi = new List<HourFolder>();
@@ -114,11 +122,11 @@ public class MoreCompactionService(
 
         for (int i = 0; i < days.Length; i++)
         {
-            int day = days[i];
+            int currentDay = days[i];
             ct.ThrowIfCancellationRequested();
-            progress?.Report(new ScanProgress(i, days.Length, day, multi.Count));
+            progress?.Report(new ScanProgress(i, days.Length, currentDay, multi.Count));
 
-            var dayPrefix = SendGridPathUtility.GetS3CompactionPrefix(year, month, day, null);
+            var dayPrefix = SendGridPathUtility.GetS3CompactionPrefix(year, month, currentDay, null);
             IEnumerable<string> hourDirs = await s3StorageService.ListDirectoriesAsync(dayPrefix, ct);
 
             foreach (int hour in hourDirs.Select(h => int.TryParse(h, out int v) ? v : -1)
@@ -126,14 +134,14 @@ public class MoreCompactionService(
                          .OrderBy(v => v))
             {
                 ct.ThrowIfCancellationRequested();
-                var hourPrefix = SendGridPathUtility.GetS3CompactionPrefix(year, month, day, hour);
+                var hourPrefix = SendGridPathUtility.GetS3CompactionPrefix(year, month, currentDay, hour);
                 IReadOnlyCollection<S3ObjectEntry> entries = await s3StorageService.ListFilesWithSizeAsync(hourPrefix, ct);
                 var parquetFiles = entries
                     .Where(e => e.Key.EndsWith(SendGridPathUtility.ParquetFileExtension, StringComparison.OrdinalIgnoreCase))
                     .OrderBy(e => e.Key, StringComparer.Ordinal)
                     .ToArray();
 
-                var folder = new HourFolder(year, month, day, hour, hourPrefix, parquetFiles);
+                var folder = new HourFolder(year, month, currentDay, hour, hourPrefix, parquetFiles);
                 allFolders.Add(folder);
                 if (parquetFiles.Length >= 2)
                 {

--- a/SendgridParquetViewer/Services/MoreCompactionService.cs
+++ b/SendgridParquetViewer/Services/MoreCompactionService.cs
@@ -65,6 +65,12 @@ public class MoreCompactionService(
         long AvailableFreeBytes,
         bool IsSufficient);
 
+    public sealed record ScanProgress(
+        int ProcessedDays,
+        int TotalDays,
+        int? CurrentDay,
+        int MultiFileFoldersFound);
+
     /// <summary>
     /// 年月の完了マーカーを取得する。存在しない場合は null を返す。
     /// </summary>
@@ -91,19 +97,27 @@ public class MoreCompactionService(
     /// 指定年月の v3compaction/yyyy/MM/dd/HH フォルダを全走査し、
     /// Parquet ファイルが 2 つ以上あるフォルダを洗い出す。
     /// </summary>
-    public async Task<ScanResult> ScanAsync(int year, int month, CancellationToken ct)
+    public async Task<ScanResult> ScanAsync(int year, int month, CancellationToken ct, IProgress<ScanProgress>? progress = null)
     {
         var monthPrefix = SendGridPathUtility.GetS3CompactionPrefix(year, month, null, null);
         IEnumerable<string> dayDirs = await s3StorageService.ListDirectoriesAsync(monthPrefix, ct);
 
+        int[] days = dayDirs.Select(d => int.TryParse(d, out int v) ? v : 0)
+            .Where(v => v > 0)
+            .OrderBy(v => v)
+            .ToArray();
+
         var allFolders = new List<HourFolder>();
         var multi = new List<HourFolder>();
 
-        foreach (int day in dayDirs.Select(d => int.TryParse(d, out int v) ? v : 0)
-                     .Where(v => v > 0)
-                     .OrderBy(v => v))
+        progress?.Report(new ScanProgress(0, days.Length, null, 0));
+
+        for (int i = 0; i < days.Length; i++)
         {
+            int day = days[i];
             ct.ThrowIfCancellationRequested();
+            progress?.Report(new ScanProgress(i, days.Length, day, multi.Count));
+
             var dayPrefix = SendGridPathUtility.GetS3CompactionPrefix(year, month, day, null);
             IEnumerable<string> hourDirs = await s3StorageService.ListDirectoriesAsync(dayPrefix, ct);
 
@@ -128,6 +142,7 @@ public class MoreCompactionService(
             }
         }
 
+        progress?.Report(new ScanProgress(days.Length, days.Length, null, multi.Count));
         return new ScanResult(year, month, allFolders, multi);
     }
 

--- a/SendgridParquetViewer/Services/MoreCompactionService.cs
+++ b/SendgridParquetViewer/Services/MoreCompactionService.cs
@@ -298,10 +298,11 @@ public class MoreCompactionService(
             foreach (S3ObjectEntry src in leftoverSources)
             {
                 ct.ThrowIfCancellationRequested();
-                if (await s3StorageService.DeleteObjectAsync(src.Key, ct))
+                if (!await s3StorageService.DeleteObjectAsync(src.Key, ct))
                 {
-                    cleaned++;
+                    throw new InvalidOperationException($"Failed to delete source after resumed cleanup: {src.Key}");
                 }
+                cleaned++;
             }
             logger.ZLogInformation($"MoreCompaction resumed cleanup: {folder.Prefix} deleted={cleaned}");
             return new MoreCompactionFolderResult(folder, Skipped: false, TotalEvents: 0, DeletedFiles: cleaned);
@@ -342,14 +343,16 @@ public class MoreCompactionService(
         await VerifyUploadedParquetAsync(outputKey, ct);
 
         // (4) 元ファイルを削除。outputKey は leftoverSources に含まれない (上で除外済み) ので 誤削除されない。
+        // 1 件でも失敗すると フォルダ内に古いソースが残り「1 parquet 保証」が崩れるため、その時点で例外にする。
         int deleted = 0;
         foreach (S3ObjectEntry src in leftoverSources)
         {
             ct.ThrowIfCancellationRequested();
-            if (await s3StorageService.DeleteObjectAsync(src.Key, ct))
+            if (!await s3StorageService.DeleteObjectAsync(src.Key, ct))
             {
-                deleted++;
+                throw new InvalidOperationException($"Failed to delete source after merge: {src.Key}");
             }
+            deleted++;
         }
 
         logger.ZLogInformation($"MoreCompaction done: {folder.Prefix} events={totalEvents} deleted={deleted}");

--- a/SendgridParquetViewer/Services/MoreCompactionService.cs
+++ b/SendgridParquetViewer/Services/MoreCompactionService.cs
@@ -97,61 +97,87 @@ public class MoreCompactionService(
     /// 指定年月 (または 年月日) の v3compaction/yyyy/MM/dd/HH フォルダを走査し、
     /// Parquet ファイルが 2 つ以上あるフォルダを洗い出す。
     /// day が指定された場合はその 1 日だけが対象。
+    ///
+    /// 実装は prefix (月 or 日) 配下を 1 回の再帰 LIST で取得し、キー文字列から
+    /// yyyy/MM/dd/HH を分解してグループ化する。ディレクトリ単位に LIST を
+    /// 繰り返すよりも HTTP 往復回数が激減する。
     /// </summary>
     public async Task<ScanResult> ScanAsync(int year, int month, CancellationToken ct, IProgress<ScanProgress>? progress = null, int? day = null)
     {
-        int[] days;
-        if (day is { } d)
+        // 月モード: v3compaction/yyyy/MM  /  日モード: v3compaction/yyyy/MM/dd
+        string prefix = SendGridPathUtility.GetS3CompactionPrefix(year, month, day, null);
+
+        progress?.Report(new ScanProgress(0, 0, null, 0));
+
+        IReadOnlyCollection<S3ObjectEntry> entries = await s3StorageService.ListFilesWithSizeAsync(prefix, ct);
+        ct.ThrowIfCancellationRequested();
+
+        // (yyyy, MM, dd, HH) にグループ化。キー分解に失敗したもの (例: morecompaction.json や
+        // 不正なパス) はスキップ。
+        var grouped = new Dictionary<(int Year, int Month, int Day, int Hour), List<S3ObjectEntry>>();
+        foreach (S3ObjectEntry entry in entries)
         {
-            days = [d];
-        }
-        else
-        {
-            var monthPrefix = SendGridPathUtility.GetS3CompactionPrefix(year, month, null, null);
-            IEnumerable<string> dayDirs = await s3StorageService.ListDirectoriesAsync(monthPrefix, ct);
-            days = dayDirs.Select(x => int.TryParse(x, out int v) ? v : 0)
-                .Where(v => v > 0)
-                .OrderBy(v => v)
-                .ToArray();
-        }
-
-        var allFolders = new List<HourFolder>();
-        var multi = new List<HourFolder>();
-
-        progress?.Report(new ScanProgress(0, days.Length, null, 0));
-
-        for (int i = 0; i < days.Length; i++)
-        {
-            int currentDay = days[i];
-            ct.ThrowIfCancellationRequested();
-            progress?.Report(new ScanProgress(i, days.Length, currentDay, multi.Count));
-
-            var dayPrefix = SendGridPathUtility.GetS3CompactionPrefix(year, month, currentDay, null);
-            IEnumerable<string> hourDirs = await s3StorageService.ListDirectoriesAsync(dayPrefix, ct);
-
-            foreach (int hour in hourDirs.Select(h => int.TryParse(h, out int v) ? v : -1)
-                         .Where(v => v >= 0)
-                         .OrderBy(v => v))
+            if (!entry.Key.EndsWith(SendGridPathUtility.ParquetFileExtension, StringComparison.OrdinalIgnoreCase))
             {
-                ct.ThrowIfCancellationRequested();
-                var hourPrefix = SendGridPathUtility.GetS3CompactionPrefix(year, month, currentDay, hour);
-                IReadOnlyCollection<S3ObjectEntry> entries = await s3StorageService.ListFilesWithSizeAsync(hourPrefix, ct);
-                var parquetFiles = entries
-                    .Where(e => e.Key.EndsWith(SendGridPathUtility.ParquetFileExtension, StringComparison.OrdinalIgnoreCase))
-                    .OrderBy(e => e.Key, StringComparer.Ordinal)
-                    .ToArray();
+                continue;
+            }
+            if (!TryParseCompactionKey(entry.Key, out int y, out int m, out int d, out int h))
+            {
+                continue;
+            }
+            if (y != year || m != month || (day is { } dd && d != dd))
+            {
+                // prefix の想定から外れるキーは無視 (防御的)
+                continue;
+            }
+            var groupKey = (y, m, d, h);
+            if (!grouped.TryGetValue(groupKey, out var list))
+            {
+                list = new List<S3ObjectEntry>();
+                grouped[groupKey] = list;
+            }
+            list.Add(entry);
+        }
 
-                var folder = new HourFolder(year, month, currentDay, hour, hourPrefix, parquetFiles);
-                allFolders.Add(folder);
-                if (parquetFiles.Length >= 2)
-                {
-                    multi.Add(folder);
-                }
+        var allFolders = new List<HourFolder>(grouped.Count);
+        var multi = new List<HourFolder>();
+        foreach (var groupKey in grouped.Keys.OrderBy(k => k.Day).ThenBy(k => k.Hour))
+        {
+            List<S3ObjectEntry> bucket = grouped[groupKey];
+            S3ObjectEntry[] parquetFiles = bucket
+                .OrderBy(e => e.Key, StringComparer.Ordinal)
+                .ToArray();
+            string hourPrefix = SendGridPathUtility.GetS3CompactionPrefix(groupKey.Year, groupKey.Month, groupKey.Day, groupKey.Hour);
+            var folder = new HourFolder(groupKey.Year, groupKey.Month, groupKey.Day, groupKey.Hour, hourPrefix, parquetFiles);
+            allFolders.Add(folder);
+            if (parquetFiles.Length >= 2)
+            {
+                multi.Add(folder);
             }
         }
 
-        progress?.Report(new ScanProgress(days.Length, days.Length, null, multi.Count));
+        int distinctDays = allFolders.Select(f => f.Day).Distinct().Count();
+        progress?.Report(new ScanProgress(distinctDays, distinctDays, null, multi.Count));
         return new ScanResult(year, month, allFolders, multi);
+    }
+
+    /// <summary>
+    /// `v3compaction/yyyy/MM/dd/HH/<name>` 形式の S3 キーを年月日時に分解する。
+    /// 先頭 5 セグメント (prefix + yyyy + MM + dd + HH) をすべて int パースできた場合のみ true。
+    /// </summary>
+    private static bool TryParseCompactionKey(string key, out int year, out int month, out int day, out int hour)
+    {
+        year = month = day = hour = 0;
+        string[] parts = key.Split('/');
+        // 期待形式: ["v3compaction", "yyyy", "MM", "dd", "HH", "filename"] -> parts.Length >= 6
+        if (parts.Length < 6)
+        {
+            return false;
+        }
+        return int.TryParse(parts[1], out year)
+            && int.TryParse(parts[2], out month)
+            && int.TryParse(parts[3], out day)
+            && int.TryParse(parts[4], out hour);
     }
 
     /// <summary>

--- a/SendgridParquetViewer/Services/MoreCompactionService.cs
+++ b/SendgridParquetViewer/Services/MoreCompactionService.cs
@@ -148,7 +148,12 @@ public class MoreCompactionService(
         await JsonSerializer.SerializeAsync(ms, status, AppJsonSerializerContext.Default.MoreCompactionStatus, ct);
         ms.Seek(0, SeekOrigin.Begin);
         string key = SendGridPathUtility.GetS3MoreCompactionStatusKey(year, month);
-        await s3StorageService.PutObjectAsync(ms, key, ct);
+        bool uploaded = await s3StorageService.PutObjectAsync(ms, key, ct);
+        if (!uploaded)
+        {
+            logger.ZLogError($"Failed to write MoreCompaction status: {key}");
+            throw new InvalidOperationException($"Failed to write MoreCompaction status to '{key}'.");
+        }
         logger.ZLogInformation($"MoreCompaction status written: {key}");
         return status;
     }

--- a/SendgridParquetViewer/Services/MoreCompactionService.cs
+++ b/SendgridParquetViewer/Services/MoreCompactionService.cs
@@ -41,6 +41,17 @@ public class MoreCompactionService(
         IReadOnlyList<S3ObjectEntry> ParquetFiles)
     {
         public long TotalBytes => ParquetFiles.Sum(f => f.Size);
+
+        public long MaxFileBytes => ParquetFiles.Count == 0 ? 0L : ParquetFiles.Max(f => f.Size);
+
+        /// <summary>
+        /// ExecuteFolderAsync 実行中に一時フォルダで同時に存在しうるバイト数の安全側見積もり。
+        /// 下記 3 つが同時に乗ることを想定:
+        ///   (a) マージ出力 tempfile ≒ TotalBytes
+        ///   (b) Verify 用に再ダウンロードした tempfile ≒ TotalBytes (output は解放前なので並存)
+        ///   (c) ソース tempfile 1 本 ≒ MaxFileBytes (実装上は verify と並存しないが保守的に加算)
+        /// </summary>
+        public long EstimatedPeakTempBytes => TotalBytes * 2 + MaxFileBytes;
     }
 
     public sealed record ScanResult(
@@ -53,10 +64,10 @@ public class MoreCompactionService(
 
         /// <summary>
         /// 逐次実行時に一時的に必要となる最大ディスク量。
-        /// MoreCompaction は 1 フォルダずつ処理するため、最大サイズのフォルダ 1 つぶん。
+        /// MoreCompaction は 1 フォルダずつ処理するため、ピーク消費量が最大のフォルダ 1 つぶん。
         /// </summary>
         public long MaxTempBytesPerFolder =>
-            MultiFileFolders.Count == 0 ? 0L : MultiFileFolders.Max(f => f.TotalBytes);
+            MultiFileFolders.Count == 0 ? 0L : MultiFileFolders.Max(f => f.EstimatedPeakTempBytes);
     }
 
     public sealed record DiskSpaceEstimate(
@@ -259,12 +270,20 @@ public class MoreCompactionService(
             return new MoreCompactionFolderResult(folder, Skipped: true, TotalEvents: 0, DeletedFiles: 0);
         }
 
-        bool existingOutputPresent = sources.Any(e => string.Equals(e.Key, outputKey, StringComparison.Ordinal));
+        bool existingOutputInScan = sources.Any(e => string.Equals(e.Key, outputKey, StringComparison.Ordinal));
         IReadOnlyList<S3ObjectEntry> leftoverSources = sources
             .Where(e => !string.Equals(e.Key, outputKey, StringComparison.Ordinal))
             .ToArray();
 
-        // (A) 前回実行がアップロード成功後に元ソース削除の途中で中断したケース。
+        // スキャンから実行までに別セッション等で outputKey が作られているかもしれないので、
+        // 実行時点でも outputKey の存在を S3 に問い合わせ直して保守的に確認する。
+        // (スキャン結果だけに依存すると TOCTOU で 完成済み merged を上書きし、
+        // 元ソースが部分削除されているタイミングだと データ欠損 parquet で塗り替える恐れがある。)
+        bool existingOutputLive = await s3StorageService.AnyFileExistsAsync(outputKey, ct);
+        bool existingOutputPresent = existingOutputInScan || existingOutputLive;
+
+        // (A) 前回実行がアップロード成功後に元ソース削除の途中で中断したケース、または
+        // スキャン後に別実行者がアップロードしたケース。
         // outputKey が読めることを確認した上で、残ソースの削除のみ行う。
         // ここで outputKey を削除 → 残ソースから再マージ、としてしまうと、
         // 元ソースが部分削除されている場合に完成済み merged データを失う恐れがある。

--- a/SendgridParquetViewer/Services/SlackNotifier.cs
+++ b/SendgridParquetViewer/Services/SlackNotifier.cs
@@ -1,4 +1,4 @@
-using System.Net.Http.Json;
+﻿using System.Net.Http.Json;
 
 using Microsoft.Extensions.Options;
 

--- a/codinglog/Gpt202604211804.md
+++ b/codinglog/Gpt202604211804.md
@@ -1,0 +1,79 @@
+# 追加コンパクション (MoreCompaction) 機能の実装
+
+## プロンプト要約
+
+現在の Compaction 処理は途中で失敗するケースで `v3compaction/yyyy/MM/dd/HH/` の下に
+複数の parquet ファイルが生成されることがあるため、これを 1 ファイルにまとめる処理を
+画面 (MoreCompaction.razor) から手動実行できるようにする。
+
+- 自動実行はしない
+- 年月を選択。先月以前のみ指定可能
+  - 完了マーカー JSON が存在すれば「処理完了済み」表示
+  - なければスキャンし、2 parquet 以上あるフォルダを列挙 / すべて 1 parquet ならマーカー生成
+- 実行 (特定 yyyy/MM/dd/HH)
+  - 出力ファイル名は固定 (`morecompaction.parquet`)
+  - 実行開始時に出力キーを削除 (アップロード中断対策)
+  - メモリ使用量注意 (多数レコード想定)
+  - 一時フォルダに 1 parquet → S3 アップロード → 元ファイル削除
+  - 想定最大ディスク消費量と空き容量の見積もり、不足時に警告
+
+## 実装
+
+- `SendGridPathUtility`: `MoreCompactionFileName`, `MoreCompactionStatusFileName`,
+  `GetS3MoreCompactionParquetKey`, `GetS3MoreCompactionStatusKey` を追加
+- `S3StorageService`: `S3ObjectEntry` 構造体と `ListFilesWithSizeAsync` を追加
+  (ディスク消費量見積もり用に Size を取得)
+- `MoreCompactionStatus`: 年月ごとの完了マーカー。`AppJsonSerializerContext` に登録
+- `MoreCompactionService`:
+  - `GetStatusAsync` / `ScanAsync` / `WriteStatusAsync` / `EstimateDiskSpace` / `ExecuteFolderAsync`
+  - `ExecuteFolderAsync` は既存出力キーを DELETE → `IAsyncEnumerable<SendGridEvent>` で
+    `ParquetService.ConvertToParquetStreamingAsync` にストリーミング → 検証 → 元ファイル削除
+  - 全てストリーミング処理でメモリ使用量を抑制
+- `MoreCompaction.razor` (`/more-compaction`): 年・月入力 (デフォルト先月)、
+  スキャン結果 (フォルダ一覧、ファイル数、サイズ)、ディスク空き容量 / 警告、
+  フォルダ単位 / 一括実行ボタン、実行ログ
+- `NavMenu.razor` に「追加コンパクション」リンクを追加
+- `Program.cs` に `MoreCompactionService` を DI 登録
+
+## 検証
+
+- `dotnet build`: 成功 (新規 warning なし)
+- `dotnet format`: 実行済み (既存ファイル 4 件に UTF-8 BOM 追加)
+- `dotnet test`: 7/7 Pass
+
+## プルリクエストメッセージ案
+
+```
+追加コンパクション (MoreCompaction) 画面を追加 (#features/morecompaction)
+
+通常の Compaction 処理が途中で失敗すると v3compaction/yyyy/MM/dd/HH/ の下に
+複数の parquet ファイルが残ることがある。この残骸を手動操作で 1 ファイルへ
+統合する「追加コンパクション」画面を SendgridParquetViewer に追加した。
+
+## 使い方
+
+- /more-compaction を開く
+- 年・月を指定 (先月以前のみ)
+- 「スキャン」で対象フォルダ一覧を取得
+  - 完了マーカー (v3compaction/yyyy/MM/morecompaction.json) があれば処理済み表示
+  - 全フォルダが 1 parquet のみの場合は完了マーカーを書き込める
+  - 2 parquet 以上のフォルダは表で一覧表示
+- 「実行」(フォルダ単位) もしくは「すべて実行」で統合を実行
+  - 出力先: v3compaction/yyyy/MM/dd/HH/morecompaction.parquet (固定名)
+  - 処理順: 出力キーの DELETE → ストリーミング生成 → S3 PUT → 検証 → 元ファイル DELETE
+
+## 実装ポイント
+
+- すべて IAsyncEnumerable / RowGroup 逐次処理でメモリに全件をロードしない
+  (CompactionService 同様 RowGroupSize=60_000)
+- 一時フォルダ直下のドライブ空き容量と 最大フォルダサイズ を見積もり、不足時に警告
+- 既存出力ファイルを必ず削除してからアップロードするので、途中中断しても再実行で上書き復旧
+
+## 主な変更
+
+- SendGridPathUtility: MoreCompaction 用パス生成
+- S3StorageService: ListFilesWithSizeAsync (Key + Size)
+- MoreCompactionService / MoreCompactionStatus (新規)
+- MoreCompaction.razor (新規, /more-compaction)
+- NavMenu / Program / AppJsonSerializerContext の DI / ナビ追加
+```


### PR DESCRIPTION
## Summary

通常の Compaction が途中で失敗して `v3compaction/yyyy/MM/dd/HH/` に複数 parquet が残る状況を、画面から手動で 1 フォルダ 1 parquet へ統合できる「追加コンパクション」ページ (`/more-compaction`) を追加。

- **年月 / 年月日の 2 モード**: `FluentDatePicker` + `FluentRadioGroup` で切替。年月モードは月全体、年月日モードはその日 1 日のみをスキャン。
- **出力ファイル名は folder-unique かつ通常 Compaction と区別可能**: `morecompaction<yyyyMMddHH>.parquet`。通常 Compaction 出力 (ハッシュ名) と区別でき、同名衝突も無い。
- **スキャン進捗 UI**: `IProgress<ScanProgress>` で処理中の yyyy/MM/dd と件数を表示。
- **個別実行の成功行は即座に表から消える** (再スキャン不要)。
- **完了マーカー** (`v3compaction/yyyy/MM/morecompaction.json`) は年月モード専用。二重処理を回避。
- **ストリーミング書き込み** (RowGroup=60_000) と **一時ディスク空き容量の事前警告** で大容量フォルダでも実行可能。
- **GitHub Actions を Node.js 24 対応版に更新** (checkout v6 / setup-buildx v4 / login v4 / metadata v6 / build-push v7)。

## 画面フロー

1. `/more-compaction` を開く
2. DatePicker で対象日付を選択 (既定: 先月 1 日 / 先月以前のみ許可)
3. モード選択:
   - **年月のみ使用 (日付は無視)**: 月全体を走査、完了マーカー書き込みボタンあり
   - **年月日すべて使用**: その日 1 日のみ走査、完了マーカーは書かない
4. 「スキャン」→ 進捗表示付きで対象一覧取得
5. 「実行」(行単位) / 「すべて実行」
   - 出力: `v3compaction/yyyy/MM/dd/HH/morecompaction<yyyyMMddHH>.parquet`
   - 手順: 既存出力キー DELETE → ストリーミング生成 → S3 PUT → 再読込検証 → 元ファイル DELETE
   - 成功した行はテーブルから即座に消える

## 主な変更

- `SendgridParquet.Shared`
  - `S3StorageService.ListFilesWithSizeAsync` と `S3ObjectEntry` を追加 (Key + Size)
  - `SendGridPathUtility`: `GetMoreCompactionFileName` / `GetS3MoreCompactionParquetKey` / `GetS3MoreCompactionStatusKey` / `MoreCompactionStatusFileName`
- `SendgridParquetViewer`
  - `Services/MoreCompactionService`: スキャン (日指定可) / 実行 / 完了マーカー / ディスク見積もり / 進捗通知
  - `Components/Pages/MoreCompaction.razor`: DatePicker + モードラジオ / 進捗 UI / 成功行の除去 / カレンダーポップアップが隠れないよう FluentCard の CSS 調整
  - `Models/MoreCompactionStatus` + `AppJsonSerializerContext` 登録
  - `Program.cs` に `MoreCompactionService` の DI 登録、`NavMenu` にリンク追加
- `.github/workflows/deploy.yml`: Actions を Node.js 24 対応版へ

## レビュー所見 (別 PR 候補)

以下は本 PR では直さず別チケット化を推奨:
- 通常 Compaction と MoreCompaction は S3 ロックを共有していない。UI 制限 (先月以前) で実運用上は回避できるが、同時実行時にイベント重複のリスクがある → `IS3LockService` 経由で同一ロックを取る案
- 画面は `[Authorize]` のみで `AuthorizationPolicies.AdminRole` 未使用。既存 `Compaction.razor` も同じ状況なのでまとめて昇格検討

## Test plan

- [x] `dotnet build` (ローカル)
- [ ] `dotnet test`
- [ ] `/more-compaction` スキャン → 進捗表示が日単位で更新される
- [ ] 年月モード: 2 parquet 以上のフォルダが 1 parquet に統合され、成功行が即消えること / すべて 1 parquet のとき完了マーカーを書けること
- [ ] 年月日モード: 指定日のみ走査、完了マーカーボタンが出ないこと
- [ ] 出力キーが `morecompaction<yyyyMMddHH>.parquet` になっていること (通常 Compaction のハッシュ名と区別可能)
- [ ] DatePicker のカレンダーが親カードで隠れずに表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
