### PR TITLE
ハングした compaction がロックを恒久保持するデッドロックを修正

### DIFF
--- a/SendgridParquetViewer/Models/RunStatusContext.cs
+++ b/SendgridParquetViewer/Models/RunStatusContext.cs
@@ -15,6 +15,20 @@ internal record RunStatusContext(RunStatus RunStatus, Action<RunStatus> NotifyRu
     internal async Task SaveRunStatusAsync(CancellationToken ct) => await SaveRunStatusAsyncFunc.Invoke(RunStatus, ct);
 
     /// <summary>
+    /// 本体の前進 (進捗) を表す最終更新時刻をスレッドセーフに取得する。
+    /// 各 Increment/Start/Completed 系メソッドが _lock 内で LastUpdated を更新するため、
+    /// ここでも同じ _lock で読むことで torn read を避ける。
+    /// ハートビートのウォッチドッグが「作業が前進しているか」を判定するために使う。
+    /// </summary>
+    internal DateTimeOffset GetLastActivityTimestamp()
+    {
+        lock (_lock)
+        {
+            return RunStatus.GetLastActivityTimestamp();
+        }
+    }
+
+    /// <summary>
     /// 1日分のコンパクションを開始したことを記録する
     /// </summary>
     public void StartADay(DateOnly targetDate, int totalFiles, DateTimeOffset now)

--- a/SendgridParquetViewer/Services/CompactionService.cs
+++ b/SendgridParquetViewer/Services/CompactionService.cs
@@ -29,6 +29,10 @@ public class CompactionService(
     private readonly SemaphoreSlim _startupTaskSemaphore = new(1);
     private readonly CompactionOptions _compactionOptions = compactionOptions.Value;
     private readonly IS3LockService _s3LockService = s3LockService;
+    // stall 判定およびハートビートの進捗ウォッチドッグの閾値。
+    // 注意: バッチ内の変換フェーズ (CreateCompactedParquetAsync / ConvertToParquetStreamingAsync) の
+    // 実行中は LastUpdated が更新されないため、この値は「1バッチの変換にかかる最悪時間」より
+    // 十分大きく取る必要がある (短くしすぎると正常な巨大バッチを誤ってストール扱いにする)。
     private static readonly TimeSpan MaxInactivityDuration = TimeSpan.FromDays(1);
     private TimeSpan LockHeartbeatInterval => _s3LockService.LockDuration / 6;
 

--- a/SendgridParquetViewer/Services/CompactionService.cs
+++ b/SendgridParquetViewer/Services/CompactionService.cs
@@ -343,7 +343,7 @@ public class CompactionService(
         // 本体は token ではなくこの compactionToken を監視する。
         using var compactionCts = CancellationTokenSource.CreateLinkedTokenSource(token);
         CancellationToken compactionToken = compactionCts.Token;
-        Task lockHeartbeatTask = RunLockHeartbeatAsync(runStatus.LockId, compactionCts);
+        Task lockHeartbeatTask = RunLockHeartbeatAsync(runStatusContext, compactionCts);
 
         try
         {
@@ -387,6 +387,11 @@ public class CompactionService(
     }
 
     /// <summary>
+    /// 各 tick はまず進捗ウォッチドッグを見る: in-memory の LastUpdated が
+    /// MaxInactivityDuration の間更新されなければ、本体ストールとみなしロックを延長せず
+    /// compaction をキャンセルする (ロックは期限切れ→次回 run が回復可能)。
+    /// 前進が続く間だけ、以下のロック延長を行う。
+    ///
     ///   ┌───────────────────────┐              ┌───────────────┐               ┌────┐
     ///   │ RunLockHeartbeatAsync │              │ S3LockService │               │ S3 │
     ///   └───────────┬───────────┘              └───────┬───────┘               └──┬─┘
@@ -431,13 +436,29 @@ public class CompactionService(
     ///   │ RunLockHeartbeatAsync │              │ S3LockService │               │ S3 │
     ///   └───────────────────────┘              └───────────────┘               └────┘
     /// </summary>
-    private async Task RunLockHeartbeatAsync(string lockId, CancellationTokenSource cts)
+    private async Task RunLockHeartbeatAsync(RunStatusContext runStatusContext, CancellationTokenSource cts)
     {
+        string lockId = runStatusContext.RunStatus.LockId;
         while (!cts.Token.IsCancellationRequested)
         {
             try
             {
                 await Task.Delay(LockHeartbeatInterval, cts.Token);
+
+                // 進捗ウォッチドッグ: 「ロックの延長 (プロセスの生存)」と「本体の前進 (作業の進捗)」は別物。
+                // 本体が (ハング等で) 前進しなくなってもハートビートによるロック延長は成功し続けるため、
+                // それだけを根拠にロックを維持すると、ハングしたプロセスがロックを恒久的に握り続け、
+                // 次回 run が FinalizeStalledRunAsync でロックを奪えず回復不能になる。
+                // in-memory の LastUpdated が MaxInactivityDuration の間まったく更新されない場合は
+                // 本体がストールしたとみなし、ロックを延長せず本体ごと停止してロックを期限切れにする。
+                var now = timeProvider.GetUtcNow();
+                var lastActivity = runStatusContext.GetLastActivityTimestamp();
+                if (now - lastActivity > MaxInactivityDuration)
+                {
+                    logger.ZLogError($"Compaction made no progress for {now - lastActivity} (> {MaxInactivityDuration}). Stopping compaction and letting the lock expire so the next run can recover. LockId={lockId}, LastActivity={lastActivity:o}");
+                    await cts.CancelAsync();
+                    break;
+                }
 
                 // 連続失敗回数の管理としきい値判定は S3LockService 側が担う。
                 // ここではロックを維持できなくなった (Abandoned) 場合に compaction を止めるだけ。


### PR DESCRIPTION
背景 / 症状
/compaction 画面が Status: Running のまま 48h 以上停止し、毎日の compaction が回復しない不具合。

Day Progress 0/59214、Output 0、Deleted 0 が長時間変化しない
一方で run.lock の ExpiresAt だけは延び続ける（例: AcquiredAt 2026/07/04 06:00:30 → ExpiresAt 2026/07/06 00:18:38）
根本原因
「ロックのハートビート（プロセスの生存）」と「コンパクション本体の前進（作業の進捗）」が切り離されていた。

70363ac (#79) でハートビートが一時エラーで誤終了しなくなった結果、本体がハングしても RunLockHeartbeatAsync だけがロックを延々と延長し続ける状態になった。

ハートビートは本体の進捗と無関係に5分ごとにロックを延長
FinalizeStalledRunAsync は ExpiresAt が十分先だと「ハートビートが生きている＝稼働中」とみなし stall 判定をスキップ（#70 で追加）
→ ハングしたプロセスがロックを恒久的に握り、次回 run はロックを奪えず Unable to acquire lock で毎回失敗する恒久デッドロック
修正
ハートビートを進捗ウォッチドッグ化し、「ロック維持」を「作業進捗」に従属させる。

RunLockHeartbeatAsync の各 tick でまず in-memory の LastUpdated を確認。MaxInactivityDuration（1日）の間まったく更新がなければ本体ストールとみなし、ロックを延長せず cts.CancelAsync() で本体ごと停止する。ロックは期限切れ（または finally の ReleaseLockAsync で即時解放）となり、次回 run が回復できる。
RunStatusContext.GetLastActivityTimestamp() を追加し、LastUpdated を _lock 内でスレッドセーフに読めるようにする（torn read 回避）。
これにより、ハートビートによる延長が続く＝前進の証拠となり、FinalizeStalledRunAsync のスキップ判定も安全になる。本体がキャンセルを尊重すれば即時解放、無視しても最大30分で自然失効し、いずれも回復する。

現在詰まっているインスタンスの解消
本 PR をデプロイすると新リビジョン切替で旧 pod が停止 → ハートビート停止 → ロック失効（≤30分）→ 次回 run が回復する。

補足（別issue）
本体が「なぜハングしたか」は本 PR の対象外。FetchParquetFilesAsync の producer/consumer で consumer が例外で倒れると bounded channel が詰まり producer の WriteAsync が永久ブロックし得る箇所が疑わしく、別途調査の価値あり。本ウォッチドッグはこの手のハングからの回復を保証する。