### PR TITLE
FetchParquetFiles の consumer 例外で producer が永久ブロックするデッドロックを修正

### DIFF
--- a/SendgridParquetViewer/Services/CompactionService.cs
+++ b/SendgridParquetViewer/Services/CompactionService.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json;
+﻿using System.Runtime.ExceptionServices;
+using System.Text.Json;
 using System.Threading.Channels;
 
 using MemoryPack;
@@ -763,16 +764,94 @@ public class CompactionService(
             SingleWriter = true,
             FullMode = BoundedChannelFullMode.Wait,
         });
-        Task<FetchReadParquetFilesResult> consumer = FetchParquetFilesConsumerAsync(ctx, channel.Reader, token);
+        // consumer が例外で倒れると 満杯チャネルへの producer の WriteAsync が永久ブロックし、
+        // compaction が Running のままハングする。producer/consumer のどちらが倒れても
+        // linkedCts で相手の待機を解除し、デッドロックを防ぐ。
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(token);
+
+        Task producer = RunProducerAsync();
+        Task<FetchReadParquetFilesResult> consumer = RunConsumerAsync();
+
+        Exception? producerError = await CaptureAsync(producer);
+        (FetchReadParquetFilesResult? result, Exception? consumerError) = await CaptureAsync(consumer);
+
+        // 相手を巻き添えで cancel した OperationCanceledException よりも
+        // 本来の失敗原因を優先して投げる
+        if (producerError is not null and not OperationCanceledException
+            && consumerError is OperationCanceledException)
+        {
+            ExceptionDispatchInfo.Throw(producerError);
+        }
+        if (consumerError is not null)
+        {
+            ExceptionDispatchInfo.Throw(consumerError);
+        }
+        if (producerError is not null)
+        {
+            ExceptionDispatchInfo.Throw(producerError);
+        }
+        return result!;
+
+        async Task RunProducerAsync()
+        {
+            try
+            {
+                await FetchParquetFilesProducerAsync(ctx, channel.Writer, linkedCts.Token);
+            }
+            catch
+            {
+                // producer が倒れたら consumer 側の読み取り待ちを解除する
+                linkedCts.Cancel();
+                throw;
+            }
+            finally
+            {
+                channel.Writer.TryComplete();
+            }
+        }
+
+        async Task<FetchReadParquetFilesResult> RunConsumerAsync()
+        {
+            try
+            {
+                return await FetchParquetFilesConsumerAsync(ctx, channel.Reader, linkedCts.Token);
+            }
+            catch
+            {
+                // consumer が倒れたら producer の WriteAsync を解除する
+                linkedCts.Cancel();
+                throw;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Task の完了を待ち、結果か例外のいずれかを捕捉して返す（例外は再スローしない）。
+    /// producer/consumer の双方を待って本来の失敗原因を選別するために使う。
+    /// </summary>
+    private static async Task<(T? Result, Exception? Error)> CaptureAsync<T>(Task<T> task)
+    {
         try
         {
-            await FetchParquetFilesProducerAsync(ctx, channel.Writer, token);
+            return (await task, null);
         }
-        finally
+        catch (Exception ex)
         {
-            channel.Writer.TryComplete();
+            return (default, ex);
         }
-        return await consumer;
+    }
+
+    private static async Task<Exception?> CaptureAsync(Task task)
+    {
+        try
+        {
+            await task;
+            return null;
+        }
+        catch (Exception ex)
+        {
+            return ex;
+        }
     }
 
 


### PR DESCRIPTION
## 背景 / 症状
自動開始した compaction が **Running のまま進行しない**状況があった。

## 原因（デッドロック）
`CompactionService.FetchParquetFilesAsync` は producer/consumer を bounded channel（容量2, `FullMode.Wait`）で接続し、**producer を完了まで await してから** `await consumer` する構造だった。

consumer が例外で倒れると（`ParquetReader.CreateAsync` や `MemoryPackSerializer.SerializeAsync` の失敗など）チャネルを読まなくなり、producer の `writer.WriteAsync(..., token)` がチャネル満杯で**永久ブロック**する。consumer の死は `token` をキャンセルしないため解除されない。結果 `await FetchParquetFilesProducerAsync` が返らず、`finally` の `TryComplete()` にも `await consumer` にも到達せず、バッチが Running のままになる。

## 修正
- `CreateLinkedTokenSource(token)` を導入し producer/consumer 双方にリンクトークンを渡す
- `RunProducerAsync` / `RunConsumerAsync` に対称化し、**どちらが倒れても `linkedCts.Cancel()` で相手の待機を解除**
- producer の `finally` で `channel.Writer.TryComplete()`
- 例外を汎用 `CaptureAsync` ヘルパー（`Task<T>` / `Task` オーバーロード）で捕捉し、**巻き添えで cancel された `OperationCanceledException` より本来の失敗原因を優先して throw**（`ExceptionDispatchInfo.Throw`）。以後ログから原因を追える

## 検証シナリオ
- consumer 先倒れ（本命）→ producer は OCE で解除、consumer の実例外を surface
- producer 先倒れ → consumer 解除、producer の実例外を surface
- 呼び出し側 token キャンセル → 双方 OCE → OCE を surface
- ハッピーパス → result 返却
- producer/consumer とも await で例外観測済み（未観測例外なし）
- `dotnet build SendgridParquetViewer` → 0 Error

## スコープ外
「なぜ consumer が倒れたか」の根本原因は本PR対象外。本修正はハングをデッドロックさせず実例外として表面化させ、次回以降の原因究明を可能にする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)