### PR TITLE
parquet ファイル 0 件時にサーバー側で具体的なエラーメッセージを表示する

### DIFF
--- a/SendgridParquetViewer/Components/Pages/Histogram.razor
+++ b/SendgridParquetViewer/Components/Pages/Histogram.razor
@@ -59,6 +59,11 @@
     </FluentStack>
 </div>
 
+@if (!string.IsNullOrEmpty(_noFilesMessage))
+{
+    <div class="alert alert-danger mt-3" role="alert">@_noFilesMessage</div>
+}
+
 @* ヒストグラム表示 *@
 <div class="mt-3" @ref="_histogramHost"></div>
 
@@ -82,6 +87,7 @@
     private string _selectedEmail = "";
     private string _selectedEventType = SendGridEventTypes.Delivered;
     private string _selectedSgTemplateId = "";
+    private string _noFilesMessage = "";
 
     protected override async Task OnInitializedAsync()
     {
@@ -172,8 +178,11 @@
         {
             var cancellationToken = RenewCancellationToken();
 
-            IReadOnlyCollection<string> parquetUrls;
-            parquetUrls = await GetParquetUrlsAsync(cancellationToken);
+            (string s3CompactionPrefix, IReadOnlyCollection<string> parquetUrls) = await GetParquetUrlsAsync(cancellationToken);
+
+            _noFilesMessage = parquetUrls.Count == 0
+                ? $"指定した条件 ({s3CompactionPrefix}) に parquet ファイルが見つかりません。compaction が未実行の可能性があります。"
+                : "";
 
             var condition = new SearchCondition
             {
@@ -194,7 +203,14 @@
 
             if (!cancellationToken.IsCancellationRequested)
             {
-                await histogramApp.InvokeVoidAsync("runQuery", cancellationToken, condition, mode, targetDate);
+                if (parquetUrls.Count == 0)
+                {
+                    await histogramApp.InvokeVoidAsync("reset", cancellationToken);
+                }
+                else
+                {
+                    await histogramApp.InvokeVoidAsync("runQuery", cancellationToken, condition, mode, targetDate);
+                }
             }
         }
         catch (OperationCanceledException)
@@ -214,7 +230,7 @@
     /// 対象日・時間にあるファイル一覧の取得
     /// </summary>
     /// <returns></returns>
-    private async Task<IReadOnlyCollection<string>> GetParquetUrlsAsync(CancellationToken ct)
+    private async Task<(string S3Prefix, IReadOnlyCollection<string> Urls)> GetParquetUrlsAsync(CancellationToken ct)
     {
         var ymd = _dateSelectionMode switch
         {
@@ -225,7 +241,7 @@
         var s3CompactionPrefix = SendGridPathUtility.GetS3CompactionPrefix(ymd.Year, ymd.Month, ymd.Day, ymd.Hour);
         var keys = await S3StorageService.ListParquetFilesAsync(s3CompactionPrefix, ct);
         var pathPrefix = S3PresigningTransformer.PathPrefix;
-        return keys.Select(x => $"{pathPrefix}/{x}").ToArray();
+        return (s3CompactionPrefix, keys.Select(x => $"{pathPrefix}/{x}").ToArray());
     }
 
     public async ValueTask DisposeAsync()

--- a/SendgridParquetViewer/Components/Pages/Home.razor
+++ b/SendgridParquetViewer/Components/Pages/Home.razor
@@ -75,6 +75,11 @@
     </FluentStack>
 </div>
 
+@if (!string.IsNullOrEmpty(_noFilesMessage))
+{
+    <div class="alert alert-danger mt-3" role="alert">@_noFilesMessage</div>
+}
+
 @* 検索結果 *@
 <div class="mt-3" @ref="_resultHost"></div>
 
@@ -101,6 +106,7 @@
     private string _selectedEmail = "";
     private string _selectedEventType = SendGridEventTypes.Delivered;
     private string _selectedSgTemplateId = "";
+    private string _noFilesMessage = "";
 
     protected override async Task OnInitializedAsync()
     {
@@ -205,15 +211,20 @@
 
         var cancellationToken = RenewCancellationToken();
 
+        string s3CompactionPrefix;
         IReadOnlyCollection<string> parquetUrls;
         try
         {
-            parquetUrls = await GetParquetUrlsAsync(cancellationToken);
+            (s3CompactionPrefix, parquetUrls) = await GetParquetUrlsAsync(cancellationToken);
         }
         catch (OperationCanceledException)
         {
             return;
         }
+
+        _noFilesMessage = parquetUrls.Count == 0
+            ? $"指定した条件 ({s3CompactionPrefix}) に parquet ファイルが見つかりません。compaction が未実行の可能性があります。"
+            : "";
 
         var condition = new SearchCondition
         {
@@ -227,7 +238,14 @@
         {
             if (!cancellationToken.IsCancellationRequested)
             {
-                await resultApp.InvokeVoidAsync("runQuery", cancellationToken, condition);
+                if (parquetUrls.Count == 0)
+                {
+                    await resultApp.InvokeVoidAsync("reset", cancellationToken);
+                }
+                else
+                {
+                    await resultApp.InvokeVoidAsync("runQuery", cancellationToken, condition);
+                }
             }
         }
         finally
@@ -242,7 +260,7 @@
     /// 対象日・時間にあるファイル一覧の取得
     /// </summary>
     /// <returns></returns>
-    private async Task<IReadOnlyCollection<string>> GetParquetUrlsAsync(CancellationToken ct)
+    private async Task<(string S3Prefix, IReadOnlyCollection<string> Urls)> GetParquetUrlsAsync(CancellationToken ct)
     {
         var ymd = _dateSelectionMode switch
         {
@@ -253,7 +271,7 @@
         var s3CompactionPrefix = SendGridPathUtility.GetS3CompactionPrefix(ymd.Year, ymd.Month, ymd.Day, ymd.Hour);
         var keys = await S3StorageService.ListParquetFilesAsync(s3CompactionPrefix, ct);
         var pathPrefix = S3PresigningTransformer.PathPrefix;
-        return keys.Select(x => $"{pathPrefix}/{x}").ToArray();
+        return (s3CompactionPrefix, keys.Select(x => $"{pathPrefix}/{x}").ToArray());
     }
 
     public async ValueTask DisposeAsync()

--- a/codinglog/Gpt202607060727.md
+++ b/codinglog/Gpt202607060727.md
@@ -1,0 +1,28 @@
+# iPhone で DuckDB Wasm が動かないように見える問題の調査とメッセージ改善
+
+## プロンプト
+
+iPhone で duckdb Wasm 部分が動かないようです。原因は？（スクリーンショット: 検索実行後に「Select a parquet file to query.」が表示される）
+
+## 調査結果
+
+**DuckDB Wasm は原因ではない（ロードすらされていない）。**
+
+- 「Select a parquet file to query.」は `DuckDbBundle/src/index.ts` の `runQuery` 冒頭ガードで、`parquetUrls` が空のときに DuckDB 初期化（`loadDuckDb`）より前にセットされるメッセージ。
+- このエラーが Vue アプリのエラーボックスとして描画されたこと自体が、SignalR 回線・ES module 動的 import・Vue マウント・JS interop がすべて iPhone Safari 上で正常動作している証拠。
+- `parquetUrls` は端末に依存せずサーバー側（`Home.razor` / `Histogram.razor` の `GetParquetUrlsAsync`）で組み立てられる。選択日付から `v3compaction/YYYY/MM/DD` prefix を作り S3 をリストした結果が 0 件だったことが直接原因。
+- 既定日付は JST -3 日、Compaction は `TargetBefore = -1 日`（JST 昨日以前）を対象に別スケジュールで実行されるため、対象日の compaction が未実行・失敗・データ流入なしの場合にフォルダが空になる。iPhone/デスクトップの差ではなく「検索した日付・タイミング」の差。
+
+## 処理内容
+
+同じ誤解（データ不存在が DuckDB 障害に見える）を防ぐため、ファイル 0 件時のメッセージをサーバー側で具体化した。
+
+- `SendgridParquetViewer/Components/Pages/Home.razor` / `Histogram.razor`
+  - `GetParquetUrlsAsync` の戻り値を `(string S3Prefix, IReadOnlyCollection<string> Urls)` のタプルに変更し、検索に使った S3 prefix を返すようにした
+  - `RunQueryAsync` で 0 件の場合は JS の `runQuery` を呼ばず `reset` で前回結果をクリアし、Blazor 側で「指定した条件 (v3compaction/YYYY/MM/DD) に parquet ファイルが見つかりません。compaction が未実行の可能性があります。」を alert 表示する
+  - `_noFilesMessage` フィールドを追加し、検索フォーム直下に `alert alert-danger` で描画（Bootstrap は App.razor で読込済み）
+
+## 備考
+
+- 実行環境に dotnet SDK がなく（ネットワークポリシーで builds.dotnet.microsoft.com への接続が拒否）、`dotnet build` / `dotnet format` は未実施。CI での確認が必要。
+- JS バンドル（DuckDbBundle）側の変更はなし。


### PR DESCRIPTION
## parquet ファイル 0 件時にサーバー側で具体的なエラーメッセージを表示する

### 背景
iPhone で「DuckDB Wasm が動かない」との報告があったが、調査の結果 DuckDB は未ロードで、
実態は検索対象日の v3compaction 配下に parquet が存在しないケースだった。
JS 側の汎用メッセージ「Select a parquet file to query.」では原因が判別できない。

### 変更内容
- `GetParquetUrlsAsync` が検索に使った S3 prefix も返すよう変更（Home / Histogram）
- 0 件時は JS の `runQuery` を呼ばず `reset` で前回結果をクリアし、Blazor 側で
  「指定した条件 (v3compaction/YYYY/MM/DD) に parquet ファイルが見つかりません。
  compaction が未実行の可能性があります。」を alert 表示