### PR TITLE
上部バーの挨拶を削除し About にアカウント表示、Compaction タイトルのはみ出しを修正

### DIFF
--- a/SendgridParquetViewer/Components/Layout/MainLayout.razor
+++ b/SendgridParquetViewer/Components/Layout/MainLayout.razor
@@ -9,7 +9,6 @@
         <div class="top-row px-4">
             <AuthorizeView>
                 <Authorized>
-                    <span>Hello, @context.User.Identity?.Name!</span>
                     <a href="MicrosoftIdentity/Account/SignOut">Log out</a>
                 </Authorized>
                 <NotAuthorized>

--- a/SendgridParquetViewer/Components/Pages/About.razor
+++ b/SendgridParquetViewer/Components/Pages/About.razor
@@ -11,6 +11,22 @@
 
 <h1>About</h1>
 
+<section class="about-section">
+    <h2>ログインアカウント</h2>
+    <AuthorizeView>
+        <Authorized>
+            <table class="about-table">
+                <tbody>
+                    <tr>
+                        <th>アカウント</th>
+                        <td>@context.User.Identity?.Name</td>
+                    </tr>
+                </tbody>
+            </table>
+        </Authorized>
+    </AuthorizeView>
+</section>
+
 <style>
     .about-section + .about-section {
         margin-top: 2rem;

--- a/SendgridParquetViewer/Components/Pages/Compaction.razor
+++ b/SendgridParquetViewer/Components/Pages/Compaction.razor
@@ -11,7 +11,7 @@
 <PageTitle>Compaction Management</PageTitle>
 
 <FluentCard class="main-card">
-    <FluentHeader>
+    <FluentHeader Class="compaction-title-header">
         <FluentSpacer />
         <FluentLabel Typo="Typography.PageTitle">Compaction Management</FluentLabel>
         <FluentSpacer />

--- a/SendgridParquetViewer/wwwroot/app.css
+++ b/SendgridParquetViewer/wwwroot/app.css
@@ -108,3 +108,11 @@ h1:focus {
     padding: 0.75rem 1rem 1rem;
     overflow-y: auto;
 }
+
+/* Compaction ページ主タイトル: 狭い画面でのタイトルはみ出し防止 */
+.compaction-title-header {
+    height: auto !important; /* FluentHeader の固定高さを解除して内容に合わせる */
+    min-height: 48px;
+    flex-wrap: wrap;
+    padding-block: 0.5rem;
+}

--- a/codinglog/Gpt202607060743.md
+++ b/codinglog/Gpt202607060743.md
@@ -1,0 +1,43 @@
+# iPhone 表示のUI改善: 挨拶行の削除 & Compaction タイトルのはみ出し修正
+
+## プロンプト
+
+（iPhone スクリーンショットを添付のうえ）
+- 左上の「Hello, 」が不要
+- 「Compaction management」の行の文字が枠をはみ出しているのを改善したい
+
+補足確認への回答: 挨拶は行ごと全部消し、About 画面にログインアカウント表示を追加する。
+
+## 処理内容
+
+### 1. 上部バーの挨拶行を削除
+
+- `SendgridParquetViewer/Components/Layout/MainLayout.razor`
+  `<AuthorizeView>` の `<Authorized>` から `<span>Hello, @context.User.Identity?.Name!</span>` を削除。
+  Log out / About は維持。狭い画面で About が見切れる問題も緩和。
+
+### 2. About 画面にログインアカウント表示を追加
+
+- `SendgridParquetViewer/Components/Pages/About.razor`
+  `<h1>About</h1>` 直後に「ログインアカウント」セクションを追加。
+  `<AuthorizeView>` でログイン中のアカウント名 (`@context.User.Identity?.Name`) を
+  既存の `.about-section` / `.about-table` スタイルを再利用して表示。
+  ページは `[Authorize]` 済み、`_Imports.razor` に
+  `Microsoft.AspNetCore.Components.Authorization` があるため追加 using 不要。
+
+### 3. Compaction 管理画面タイトルのはみ出し修正
+
+- `SendgridParquetViewer/Components/Pages/Compaction.razor`
+  主タイトルの `FluentHeader` に `Class="compaction-title-header"` を付与。
+- `SendgridParquetViewer/wwwroot/app.css`
+  `.compaction-title-header` を追加し、固定高さの青ヘッダーを `height: auto !important`
+  + `min-height: 48px` + `flex-wrap: wrap` にして、狭い画面で2行に折り返した
+  PageTitle が枠からあふれない（下の説明文に重ならない）ようにした。青バー・中央寄せの
+  見た目は維持。
+
+## 備考
+
+- 実行環境に dotnet SDK がなく（ネットワークポリシーで builds.dotnet.microsoft.com が 403）、
+  `dotnet build` / `dotnet format` はこの環境では未実施。CI／デプロイ環境での確認が必要。
+- 前回 PR (#83) はマージ済みのため、default ブランチ (main) 最新から同名ブランチを
+  切り直して作業した。


### PR DESCRIPTION
## 上部バーの挨拶削除 / About にアカウント表示 / Compaction タイトルのはみ出し修正

### 背景
iPhone 表示で (1) 左上の「Hello, <account>!」挨拶が不要、(2) Compaction 管理画面の
タイトルが青ヘッダー枠からはみ出す、という指摘があった。

### 変更内容
- `MainLayout.razor`: 上部バーの挨拶 span を削除（Log out / About は維持）
- `About.razor`: 「ログインアカウント」セクションを追加しログイン中のアカウント名を表示
- `Compaction.razor` / `app.css`: 主タイトルの FluentHeader を height:auto 化し、
  狭い画面で PageTitle が2行に折り返しても枠内に収まるよう修正