### PR TITLE
About 画面の AuthorizeView 例外を修正

### DIFF
--- a/SendgridParquetViewer/Components/Pages/About.razor
+++ b/SendgridParquetViewer/Components/Pages/About.razor
@@ -6,6 +6,7 @@
 @using ZLogger
 @attribute [Authorize]
 @inject ILogger<About> Logger
+@inject AuthenticationStateProvider AuthenticationStateProvider
 
 <PageTitle>About</PageTitle>
 
@@ -13,18 +14,14 @@
 
 <section class="about-section">
     <h2>ログインアカウント</h2>
-    <AuthorizeView>
-        <Authorized>
-            <table class="about-table">
-                <tbody>
-                    <tr>
-                        <th>アカウント</th>
-                        <td>@context.User.Identity?.Name</td>
-                    </tr>
-                </tbody>
-            </table>
-        </Authorized>
-    </AuthorizeView>
+    <table class="about-table">
+        <tbody>
+            <tr>
+                <th>アカウント</th>
+                <td>@_accountName</td>
+            </tr>
+        </tbody>
+    </table>
 </section>
 
 <style>
@@ -209,15 +206,18 @@
     private GcMemoryInfoFormatted? _gcMemoryInfo;
     private TempFolderInfo? _tempFolderInfo;
     private IReadOnlyCollection<EnvironmentVariableEntry>? _environmentVariables;
+    private string _accountName = "";
 
-    protected override Task OnInitializedAsync()
+    protected override async Task OnInitializedAsync()
     {
+        var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        _accountName = authState.User.Identity?.Name ?? "(不明)";
+
         _gcMemoryInfo = GcMemoryInfoFormatted.Create();
         _tempFolderInfo = TempFolderInfo.Create(Logger);
         _environmentVariables = EnvironmentVariableEntry.GetMaskedEnvironmentVariables()
         .OrderBy(v => v.Name, StringComparer.OrdinalIgnoreCase)
         .ToArray();
-        return Task.CompletedTask;
     }
 
     private sealed record BuildInfo(

--- a/codinglog/Gpt202607060859.md
+++ b/codinglog/Gpt202607060859.md
@@ -1,0 +1,43 @@
+# About 画面の AuthorizeView 例外を修正
+
+## プロンプト
+
+About画面で例外が出ています。
+
+```
+System.InvalidOperationException: Authorization requires a cascading parameter of type Task<AuthenticationState>. Consider using CascadingAuthenticationState to supply this.
+Unhandled exception in circuit ...
+```
+
+## 原因
+
+- #84 で About 画面に追加した `<AuthorizeView>` が原因。
+- `About.razor` は `@rendermode InteractiveServer` のインタラクティブ島。
+  `<AuthorizeView>` は cascading の `Task<AuthenticationState>` を要求するが、供給元の
+  `<CascadingAuthenticationState>`（`Components/Routes.razor`）は静的SSR側にあり、
+  島の中には流れ込まない。`Program.cs` に `AddCascadingAuthenticationState()` も未登録。
+- `MainLayout.razor` の `<AuthorizeView>` が動くのはレイアウトが SSR 側で描画されるため。
+  `Home.razor` / `Histogram.razor` は InteractiveServer だが AuthorizeView 未使用で無影響。
+
+## 処理内容
+
+`SendgridParquetViewer/Components/Pages/About.razor` のみ変更（App 全体の認証配線には触れない）。
+
+- `@inject AuthenticationStateProvider AuthenticationStateProvider` を追加。
+- 「ログインアカウント」セクションの `<AuthorizeView>` を廃止し、`@_accountName` を
+  表示する素のテーブルに変更。
+- `OnInitializedAsync` を `async Task` 化し、先頭で
+  `AuthenticationStateProvider.GetAuthenticationStateAsync()` を await して
+  `User.Identity?.Name`（null 時は "(不明)"）を `_accountName` に格納。
+  （従来の `return Task.CompletedTask;` は削除）
+
+インタラクティブ回線で動作する推奨パターン。ページは `[Authorize]` 済みで常に認証済み。
+`AuthenticationStateProvider` は既存の `<CascadingAuthenticationState>` が依存している
+DI サービスなので追加登録は不要。
+
+## 備考
+
+- 実行環境に dotnet SDK がなく（プロキシで builds.dotnet.microsoft.com が 403）、
+  `dotnet build` / `dotnet format` はこの環境で未実施。CI／デプロイ環境での確認が必要。
+- 直近ブランチ (#84) はマージ済みのため、main 最新から新規ブランチ
+  `claude/about-auth-fix-4f166b` を切って作業。


### PR DESCRIPTION
## 背景

#84 で About 画面に追加した「ログインアカウント」表示（`<AuthorizeView>` 使用）が実行時に例外を投げていた。

```
System.InvalidOperationException: Authorization requires a cascading parameter of type
Task<AuthenticationState>. Consider using CascadingAuthenticationState to supply this.
Unhandled exception in circuit ...
```

## 原因

- `About.razor` は `@rendermode InteractiveServer`（インタラクティブ島）。
- `<AuthorizeView>` が必要とする cascading の `Task<AuthenticationState>` は、供給元の
  `<CascadingAuthenticationState>`（`Components/Routes.razor` / 静的SSR側）から島の中へは流れ込まない。
- `Program.cs` に `AddCascadingAuthenticationState()` も未登録。
- `MainLayout.razor` の `<AuthorizeView>` が動くのはレイアウトが SSR 側で描画されるため。
  `Home.razor` / `Histogram.razor` も InteractiveServer だが AuthorizeView 未使用のため無影響。

## 変更内容

`SendgridParquetViewer/Components/Pages/About.razor` のみ変更（App 全体の認証配線には非干渉）。

- `@inject AuthenticationStateProvider AuthenticationStateProvider` を追加。
- 「ログインアカウント」セクションの `<AuthorizeView>` を廃止し、`@_accountName` を表示する素のテーブルに変更。
- `OnInitializedAsync` を `async Task` 化し、先頭で `GetAuthenticationStateAsync()` を await して
  `User.Identity?.Name`（null 時は "(不明)"）を取得。

インタラクティブ回線で動作する推奨パターン。ページは `[Authorize]` 済みで常に認証済み。
`AuthenticationStateProvider` は既存の `<CascadingAuthenticationState>` が依存している DI サービスのため追加登録は不要。

## 確認方法

- About 画面を開いても例外が出ず、回線が切れないこと。
- 「ログインアカウント」にログイン中のアカウント名が表示されること。
- 既存の他セクション（ビルド情報 / GCMemoryInfo / 一時フォルダ / 環境変数）が従来どおり表示されること。

> [!NOTE]
> 作業環境に dotnet SDK がなく `dotnet build` / `dotnet format` は未実施です。CI でのビルド確認をお願いします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0128tLwUTxVcG8XraeiXwapW)_