### PR TITLE
Webhook 書き込み時に Parquet をリードバック検証し破損時は 500 で再送に委ねる

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,7 @@ In Aspire environment, these are automatically configured to use local MinIO ins
 ## S3 Storage Layout
 
 - Raw webhook uploads land under `v3raw/YYYY/MM/DD/<Base64UrlHash>.parquet`. The hash is the SHA-256 of the Parquet payload, so duplicate retries overwrite.
+- **Write-side read-back verification:** before uploading a freshly generated raw Parquet, the webhook path (`WebhookHelper.WriteParquet`) reads it back with `ParquetService.CountReadableEventsAsync` (decodes every row group) and requires the readable event count to equal the number written. If decoding throws or the count mismatches, it does **not** store the object and returns `500`, so SendGrid retries instead of silently dropping the batch (writes are content-addressed, so retries are idempotent). This closes the gap where a Parquet that is corrupt at write time would return `2xx` and only surface much later as an undecodable file during compaction. Cost: one extra in-memory decode per webhook POST (bounded by the ≤ `SENDGRID__MAXBODYBYTES` batch size).
 - Compacted hourly outputs are written to `v3compaction/YYYY/MM/DD/HH/<Base64UrlHash>.parquet`, sharing the same hashing scheme.
 - `v3compaction/run.json` tracks the active compaction run status (start/end timestamps, progress), and `v3compaction/run.lock` holds the distributed lock metadata.
 - Compaction only targets days up to the prior UTC day; once merged, the per-day folders under `v3raw` can be treated as source archives while queries should use the hourly compaction tree.

--- a/SendgridParquet.Shared/ParquetService.cs
+++ b/SendgridParquet.Shared/ParquetService.cs
@@ -316,6 +316,30 @@ public class ParquetService
         return true;
     }
 
+    /// <summary>
+    /// Parquet ストリームを実際に読み返し、全 row group の全イベントをデコードして読み取れた件数を返す。
+    /// footer を開くだけでなく列復号 (定義レベルの展開等) まで行うため、書き込み時点で壊れた
+    /// (デコード不能な) Parquet を検知するのに使える。ストリームは先頭にシークしてから読む。
+    /// デコード中の例外は握りつぶさず伝播する (呼び出し側で「読めない」と判断させるため)。
+    /// 注意: <see cref="ReadRowGroupEventsAsync"/> は必須列の読み取り失敗時に 0 行を返すため、
+    /// 返り値を期待件数と比較することで「例外を投げる破損」と「静かに 0 行になる破損」の双方を検知できる。
+    /// </summary>
+    public async Task<int> CountReadableEventsAsync(Stream parquetStream, CancellationToken token = default)
+    {
+        parquetStream.Seek(0, SeekOrigin.Begin);
+        int readCount = 0;
+        using ParquetReader reader = await ParquetReader.CreateAsync(parquetStream, cancellationToken: token);
+        for (int rowGroupIndex = 0; rowGroupIndex < reader.RowGroupCount; rowGroupIndex++)
+        {
+            using ParquetRowGroupReader rowGroupReader = reader.OpenRowGroupReader(rowGroupIndex);
+            await foreach (SendGridEvent _ in ReadRowGroupEventsAsync(rowGroupReader, reader, token))
+            {
+                readCount++;
+            }
+        }
+        return readCount;
+    }
+
     private static async Task WriteRowGroupAsync(
         ParquetWriter writer,
         IColumnBuffer[] buffers,

--- a/SendgridParquet.Shared/WebhookHelper.cs
+++ b/SendgridParquet.Shared/WebhookHelper.cs
@@ -159,6 +159,32 @@ public class WebhookHelper(
             return HttpStatusCode.InternalServerError;
         }
 
+        // 書き込み直後のリードバック検証: 生成した Parquet を PUT する前に実際に読み返し、全 row group の
+        // 全イベントをデコードできること、かつ読み取れた件数が書き込んだ件数と一致することを確認する。
+        // これにより、書き込み時点で壊れた (compaction 時に IndexOutOfRangeException 等でデコード不能になる)
+        // Parquet が S3 に保存されて 2xx を返し、SendGrid が再送しないまま欠損する事態を防ぐ。
+        // 検証に失敗した場合は 500 を返し、SendGrid の再送に委ねる (書き込みは content-addressed で冪等)。
+        try
+        {
+            int readableCount = await parquetService.CountReadableEventsAsync(parquetData, ct);
+            if (readableCount != events.Length)
+            {
+                logger.ZLogError(
+                    $"Parquet read-back verification count mismatch for {targetDay:yyyy/MM/dd}: wrote {events.Length}, read {readableCount}. Not storing; returning 500 for SendGrid retry.");
+                return HttpStatusCode.InternalServerError;
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.ZLogError(ex,
+                $"Parquet read-back verification failed to decode for {targetDay:yyyy/MM/dd} ({events.Length} events). Not storing; returning 500 for SendGrid retry.");
+            return HttpStatusCode.InternalServerError;
+        }
+
         string fileName = SendGridPathUtility.GetParquetNonCompactionFileName(targetDay, parquetData);
         bool uploadSuccess = await s3StorageService.PutObjectAsync(parquetData, fileName, ct);
         if (!uploadSuccess)


### PR DESCRIPTION
## 背景
compaction 時に `IndexOutOfRangeException`（Parquet.Net の `UnpackDefinitions` / `UnpackNullsTypeFast`）で
デコード不能になる**破損 Parquet が書き込み時点で生成**されても、従来は S3 保存に成功して SendGrid へ
`2xx` を返すため**再送されず**、後の compaction で初めて表面化してデータ欠損になっていました。

Webhook 応答の `2xx` は「parquet 生成成功 かつ S3 PUT 成功」でのみ返るため、破損オブジェクトが S3 に
存在する時点で既に `2xx` を返し終えており、SendGrid の再送は期待できません（PR #86 / #87 は
「保存済みの破損」を compaction 側で片付ける対処でした）。本 PR は**破損を書き込み時点で検知**し、
`500` を返して SendGrid の再送に委ねることで、この欠損経路を塞ぎます。

## 変更内容
### ParquetService
- `CountReadableEventsAsync(Stream, CancellationToken)` を追加。全 row group の全イベントを
  デコードして読み取れた件数を返す（footer を開くだけでなく**列復号（定義レベル展開等）まで実行**）。
  デコード中の例外は握りつぶさず伝播。

### WebhookHelper.WriteParquet
- `ConvertToParquetAsync` の直後・S3 PUT の**前**に、生成 Parquet を `CountReadableEventsAsync` で
  読み返し、**読み取れた件数 == 書き込んだ件数**を検証。
- デコード例外・件数不一致のいずれかなら**オブジェクトを保存せず `500`** を返す
  （書き込みは content-addressed で冪等なので SendGrid 再送は安全）。
- `ReadRowGroupEventsAsync` は必須列の読み取り失敗時に 0 行を返すため、件数比較により
  「例外を投げる破損」と「静かに 0 行になる破損」の**双方を検知**できる。

### ドキュメント
- AGENTS.md（S3 Storage Layout）に本検証と、webhook あたり 1 回の追加デコードコストを追記。

## トレードオフ
- webhook のホットパスで**1 リクエストあたり 1 回の追加デコード**が発生（CPU コスト）。
  ただし 1 バッチは `SENDGRID__MAXBODYBYTES`（既定 1MB, ≈900 events）に制限され、
  デコードは in-memory ストリームに対して行うため S3 再 GET は不要。
- 破損が**決定的**（特定入力で必ず再現）なエンコーダバグの場合、SendGrid が再送しても同じ破損を
  再生成するため本 PR だけでは復元できないが、少なくとも**サイレント欠損を可視化**（Error ログ + 500）し、
  健全なデータの取りこぼしを防ぐ。

## テスト
- `dotnet build` 成功 / 既存ユニットテスト 7 件 Pass
- 結合確認（実測）:
  - 有効な parquet（250 events）は読み返し件数が書込件数と一致 → 検証通過（2xx）
  - truncated / 空ストリームは読み返しで throw → 検証失敗（→ 500 → SendGrid 再送）

🤖 Generated with [Claude Code](https://claude.com/claude-code)